### PR TITLE
Begin work on 0.6

### DIFF
--- a/examples/0.6/20na_20161027.xml
+++ b/examples/0.6/20na_20161027.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="_20NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="_20NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="_20na_20161027.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/0.6/20na_20161027.xml
+++ b/examples/0.6/20na_20161027.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="_20NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="_20na_20161027.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Amy Peterson</geo:preparedBy>
+                <geo:datePrepared>2016-10-27</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Alice Plaza Building</geo:siteName>
+                <geo:fourCharacterID>20NA</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>59972M001</geo:iersDOMESNumber>
+                <geo:cdpNumber>NONE</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">ROOF</geo:monumentDescription>
+                <geo:heightOfTheMonument>0.0</geo:heightOfTheMonument>
+                <geo:monumentFoundation>ROOF</geo:monumentFoundation>
+                <geo:foundationDepth>0.0</geo:foundationDepth>
+                <geo:markerDescription>STAINLESS STEEL POST</geo:markerDescription>
+                <geo:dateInstalled>2008-03-26T00:00:00Z</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type"></geo:geologicCharacteristic>
+                <geo:bedrockType></geo:bedrockType>
+                <geo:bedrockCondition></geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type"></geo:faultZonesNearby>
+                <geo:notes>Antenna mounted on stainless steel pole which is affixed to concrete on roof top of Alice Plaza building</geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Alice Springs</geo:city>
+                <geo:state>Northern Territory</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-4050985.562 4212133.769 -2547954.522</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-23.6981910472 133.882753417 607.098</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes></geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:manufacturerSerialNumber>461571</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200PRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200PRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>5.62</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2008-03-26T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2008-03-26T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>5350026</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAX1202GG NONE" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAX1202GG     NONE</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BAM</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">NONE</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType></geo:antennaCableType>
+                <geo:antennaCableLength>0.0</geo:antennaCableLength>
+                <geo:dateInstalled>2008-03-26T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2008-03-26T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="frequency-standard-1">
+                <geo:standardType codeSpace="urn:ga-gov-au:frequency-standard-type">QUARTZ/INTERNAL</geo:standardType>
+                <geo:inputFrequency>0.0</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="frequency-standard-1--time-period-1">
+                        <gml:beginPosition>2008-03-26</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2008-03-26</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Amy Peterson</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Department Infrastructure, Planning &amp; Logistics</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(08)8995 5361</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 1680, Darwin NT 0801</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>amy.peterson@nt.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Survey Services</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Department Infrastructure, Planning &amp; Logistics</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(08) 8995 5360</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 1680, Darwin NT 0801</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Survey.Services@nt.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>GA (ftp.ga.gov.au)</geo:dataCenter>
+                <geo:dataCenter>N/A</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap>Y</geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>Y</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>Y</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+        <geo:associatedDocument>
+            <geo:Document gml:id="image_1">
+                <gml:description>Antenna North Facing</gml:description>
+                <gml:name>20NA_ant_000_20161027T143000.jpg</gml:name>
+                <geo:type>image</geo:type>
+                <geo:createdDate>2016-10-27T14:30:00Z</geo:createdDate>
+                <geo:receivedDate>2016-11-04T10:00:00Z</geo:receivedDate>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="https://gnss-site-images-dev.s3-ap-southeast-2.amazonaws.com/20NA_ant_000_20161027T143000.jpg"/>
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/21na_20161027.xml
+++ b/examples/0.6/21na_20161027.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="_21NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="_21NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="_21na_20161027.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/0.6/21na_20161027.xml
+++ b/examples/0.6/21na_20161027.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="_21NA00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="_21na_20161027.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Amy Peterson</geo:preparedBy>
+                <geo:datePrepared>2016-10-27</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Alice AZRI</geo:siteName>
+                <geo:fourCharacterID>21NA</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>50132M001</geo:iersDOMESNumber>
+                <geo:cdpNumber>NONE</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">ROOF</geo:monumentDescription>
+                <geo:heightOfTheMonument>0.0</geo:heightOfTheMonument>
+                <geo:monumentFoundation>ROOF</geo:monumentFoundation>
+                <geo:foundationDepth>0.0</geo:foundationDepth>
+                <geo:markerDescription>STAINLESS STEEL POST</geo:markerDescription>
+                <geo:dateInstalled>2008-03-27T00:00:00Z</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type"></geo:geologicCharacteristic>
+                <geo:bedrockType></geo:bedrockType>
+                <geo:bedrockCondition></geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type"></geo:faultZonesNearby>
+                <geo:notes>Antenna mounted on stainless steel pole which is affixed to concrete on roof top of building DOMES number changed from APREF to IERS</geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Alice Springs</geo:city>
+                <geo:state>Northern Territory</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-4048579.157 4210151.484 -2554917.318</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-23.7669887222 133.879218608 574.467</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes></geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:manufacturerSerialNumber>461537</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200PRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200PRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>5.62</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2008-03-27T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2008-03-27T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>5170149</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAX1202GG NONE" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAX1202GG     NONE</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BAM</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">NONE</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType></geo:antennaCableType>
+                <geo:antennaCableLength>0.0</geo:antennaCableLength>
+                <geo:dateInstalled>2008-03-27T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2008-03-27T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="frequency-standard-1">
+                <geo:standardType codeSpace="urn:ga-gov-au:frequency-standard-type">QUARTZ/INTERNAL</geo:standardType>
+                <geo:inputFrequency>0.0</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="frequency-standard-1--time-period-1">
+                        <gml:beginPosition>2008-03-27</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2008-03-27</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Amy Peterson</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Department Infrastructure, Planning &amp; Logistics</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(08)8995 5361</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 1680, Darwin NT 0801</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>amy.peterson@nt.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Survey Services</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Department Infrastructure, Planning &amp; Logistics</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(08) 8995 5360</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 1680, Darwin NT 0801</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Survey.Services@nt.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>GA (ftp.ga.gov.au)</geo:dataCenter>
+                <geo:dataCenter>N/A</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap>Y</geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>Y</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>Y</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/MOBS.xml
+++ b/examples/0.6/MOBS.xml
@@ -1,0 +1,963 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<geo:GeodesyML gml:id="GEO_1" xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xsi:schemaLocation="urn:xml-gov-au:icsm:egeodesy:0.5 ../schemas/geodesyML.xsd">
+    <!--
+        @Name MOBS_SiteLog.xml
+        @Author Laurence Davies
+        @Date 2015-06-03
+        @Description: Demonstration file using GeodesyML 0.3 to demonstrate encapsulation of a site, site-log, regulation 13 site certificate, and a national adjustment weekly solution time series.
+    -->
+    <geo:Site gml:id="SITE_1">
+        <geo:type codeSpace="">CORS</geo:type>
+        <geo:Monument xlink:href="#MONUMENT_1"/>
+    </geo:Site>
+    <geo:Monument gml:id="MONUMENT_1">
+        <gml:description>Centre of base of 5/8&quot; spigot on GPS</gml:description>
+        <gml:name codeSpace="urn:ga-gov-au:monument-siteName">Melbourne Observatory</gml:name>
+        <gml:name codeSpace="urn:ga-gov-au:monument-fourCharacterID">MOBS</gml:name>
+        <gml:name codeSpace="urn:ga-gov-au:monument-iersDOMESNumber">50182M001</gml:name>
+        <gml:name codeSpace="urn:ga-gov-au:monument-cdpNumber">Not Available</gml:name>
+        <geo:type codeSpace="urn:ga-gov-au:monument-type">CORS</geo:type>
+        <geo:installedDate>2002-09-15Z</geo:installedDate>
+        <geo:notes>antenna mounting plate fixed to 1.5m stainless steel pole. Pole is fixed to 0.6m diameter bluestone pillar The GPS antenna is located on top of a stainless steel pillar, which has been secured into the top of a bluestone pillar set in bedrock</geo:notes>
+        <geo:inscription/>
+        <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description">Centre of base of 5/8&quot; spigot on GPS</geo:monumentDescription>
+        <geo:height uomLabels="m">1.5</geo:height>
+        <geo:foundation codeSpace="urn:ga-gov-au:monument-foundation">Concrete cast in situ, set in Bedrock</geo:foundation>
+        <geo:foundationDepth uomLabels="m">4.9</geo:foundationDepth>
+        <geo:markerDescription>Stainless Steel Plate</geo:markerDescription>
+        <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:monument-geologicCharacteristic">Thin Bedrock of between 5-20m of</geo:geologicCharacteristic>
+        <geo:bedrockType codeSpace="urn:ga-gov-au:monument-bedrockType">SANDSTONE</geo:bedrockType>
+        <geo:bedrockCondition codeSpace="urn:ga-gov-au:monument-bedrockCondition">>Firm, variably oxidised, variably cemented</geo:bedrockCondition>
+        <geo:fractureSpacing codeSpace="urn:ga-gov-au:monument-fractureSpacing">No Fractures</geo:fractureSpacing>
+        <geo:faultZonesNearby codeSpace="urn:ga-gov-au:monument-faultZonesNearby">Non documented</geo:faultZonesNearby>
+    </geo:Monument>
+    <geo:GnssReceiver gml:id="GNSS_REC_1">
+        <geo:manufacturerSerialNumber>ZR520021114</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:igsModelCode>
+        <geo:satelliteSystem>GPS</geo:satelliteSystem>
+        <geo:firmwareVersion>ZC00</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2002-10-29T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2006-01-23T23:59:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_2">
+        <geo:manufacturerSerialNumber>ZR220012001</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="ASHTECH UZ-12">ASHTECH UZ-12</geo:igsModelCode>
+        <geo:satelliteSystem>GPS</geo:satelliteSystem>
+        <geo:firmwareVersion>CK00</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2006-01-24T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2007-06-20T23:59:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_3">
+        <geo:manufacturerSerialNumber>462891</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200PRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS</geo:satelliteSystem>
+        <geo:firmwareVersion>3.10</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2007-06-21T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2008-11-16T23:59:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_4">
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>6.02</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2008-11-17T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2009-07-23T23:59:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_5">
+        <geo:notes>The tracking was changed from C2 or P2, to P2 only at 2009-07-30T00 Tracking changed to all in view at 2009-09-09T01</geo:notes>
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>7.50</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2009-07-24T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2010-05-03T04:30:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_6">
+        <geo:notes>ME upgrade due to GLONASS tracking problem.</geo:notes>
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>7.50/3.019</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2010-05-03T04:30:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2010-08-05T00:00:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_7">
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>8.00/3.019</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2010-08-05T00:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2010-10-08T03:15:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_8">
+        <geo:notes>FW update for BKG RTK caster issue</geo:notes>
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>8.01/3.019</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2010-10-08T03:15:00Z</geo:dateInstalled>
+        <geo:dateRemoved>2013-06-24T02:00:00Z</geo:dateRemoved>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssReceiver gml:id="GNSS_REC_9">
+        <geo:manufacturerSerialNumber>356538</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-receiver-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO">LEICA GRX1200GGPRO</geo:igsModelCode>
+        <geo:satelliteSystem>GPS+GLONASS</geo:satelliteSystem>
+        <geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
+        <geo:elevationCutoffSetting>0</geo:elevationCutoffSetting>
+        <geo:dateInstalled>2013-06-24T02:00:00Z</geo:dateInstalled>
+        <geo:dateRemoved indeterminatePosition="unknown"/>
+        <geo:temperatureStabilization xsi:nil="true"/>
+    </geo:GnssReceiver>
+    <geo:GnssAntenna gml:id="GNSS_ANT_1">
+        <geo:manufacturerSerialNumber>CR20020709</geo:manufacturerSerialNumber>
+        <geo:igsModelCode codeSpace="urn:igs-org:gnss-antenna-model-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="ASH701945C_M">ASH701945C_M</geo:igsModelCode>
+        <geo:antennaReferencePoint>BPA</geo:antennaReferencePoint>
+        <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+        <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+        <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+        <geo:alignmentFromTrueNorth>0</geo:alignmentFromTrueNorth>
+        <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-antenna-radome-type">NONE</geo:antennaRadomeType>
+        <geo:radomeSerialNumber/>
+        <geo:antennaCableType/>
+        <geo:antennaCableLength>12</geo:antennaCableLength>
+        <geo:dateInstalled>2002-10-21Z</geo:dateInstalled>
+        <geo:dateRemoved/>
+    </geo:GnssAntenna>
+    <geo:SiteCertificate gml:id="SITECERT_1">
+        <geo:aggregationType codeSpace="urn:ga-gov-au:node-reg13-certificate"/>
+        <gml:validTime>
+            <gml:TimePeriod gml:id="SC_TP_1">
+                <gml:beginPosition>2013-11-04Z</gml:beginPosition>
+                <gml:endPosition>2018-11-03Z</gml:endPosition>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:atSite xlink:href="#SITE_1"/>
+        <geo:associatedDocument>
+            <geo:Document gml:id="DOC_1">
+                <geo:type>PDF</geo:type>
+                <geo:createdDate>2013-11-04Z</geo:createdDate>
+                <geo:receivedDate>2013-11-04Z</geo:receivedDate>
+                <geo:custodian xlink:href="#DrJohnDawsonGA"/>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="https://icsm.govspace.gov.au/files/2015/06/MOBS_Reg13certificate2014.pdf"
+                    />
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+        <geo:FourCharID>MOBS</geo:FourCharID>
+        <geo:Location>The station is located at the old Melbourne Observatory in the Royal Melbourne Botanical Gardens.</geo:Location>
+        <geo:MarkDescription>Antenna is attached on top of a stainless steel pillar which has been secured intot the top of a bluestone pillar set in bedrock.</geo:MarkDescription>
+        <geo:GNSSReceiver xlink:href="#GNSS_REC_3"/>
+        <geo:GNSSAntenna xlink:href="#GNSS_ANT_1"/>
+        <geo:AntennaOffset uomLabels="m">0.0000</geo:AntennaOffset>
+        <geo:Photo/>
+    </geo:SiteCertificate>
+    <geo:Position gml:id="POS_1_H" srsName="http://www.opengis.net/gml/srs/epsg.xml#4283">
+        <geo:atNode xlink:href="#SITECERT_1"/>
+        <geo:Status>
+            <geo:currentStatus>
+                <gml:validTime xlink:href="#POS_TP_1"/>
+                <geo:statusCode codeSpace="urn:ga-gov-au:position-status">Authoritative</geo:statusCode>
+            </geo:currentStatus>
+        </geo:Status>
+        <geo:coordinates srsName="http://www.opengis.net/gml/srs/epsg.xml#4283"
+            axisLabels="latitude longitude" uomLabels="degrees degrees">-37.82941637
+            144.9753352</geo:coordinates>
+        <gml:validTime>
+            <gml:TimePeriod gml:id="POS_TP_1">
+                <gml:beginPosition>2013-11-04Z</gml:beginPosition>
+                <gml:endPosition>2018-11-04Z</gml:endPosition>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:VCV2D codeSpace="urn:ga-gov-au:position-quality-horizontal" uomLabels="m"
+            axisLabels="latitude longitude">0.007 0 0 0.007</geo:VCV2D>
+    </geo:Position>
+    <geo:Position gml:id="POS_1_V" srsName="http://www.opengis.net/gml/srs/epsg.xml#4283">
+        <geo:atNode xlink:href="#SITECERT_1"/>
+        <geo:Status>
+            <geo:currentStatus>
+                <gml:validTime xlink:href="#POS_TP_2"/>
+                <geo:statusCode codeSpace="urn:ga-gov-au:position-status">Authoritative</geo:statusCode>
+            </geo:currentStatus>
+        </geo:Status>
+        <geo:coordinates srsName="http://www.opengis.net/gml/srs/epsg.xml#4283"
+            axisLabels="ellipsoid-height" uomLabels="m">40.6757</geo:coordinates>
+        <gml:validTime>
+            <gml:TimePeriod gml:id="POS_TP_2">
+                <gml:beginPosition>2013-11-04Z</gml:beginPosition>
+                <gml:endPosition>2018-11-04Z</gml:endPosition>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:NumericSingleQuality codeSpace="urn:ga-gov-au:position-quality-ellip-height"
+            uomLabels="m">0.017</geo:NumericSingleQuality>
+    </geo:Position>
+    <geo:siteLog gml:id="SITELOG_1">
+        <geo:atSite xlink:href="#SITE_1"/>
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy/>
+                <geo:datePrepared/>
+                <geo:reportType/>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Melbourne Observatory</geo:siteName>
+                <geo:fourCharacterID>MOBS</geo:fourCharacterID>
+                <geo:iersDOMESNumber>50182M001</geo:iersDOMESNumber>
+                <geo:cdpNumber>Not Available</geo:cdpNumber>
+                <geo:monumentDescription>Centre of base of 5/8&quot; spigot on GPS</geo:monumentDescription>
+                <geo:heightOfTheMonument>1.5</geo:heightOfTheMonument>
+                <geo:monumentFoundation>Concrete cast in situ, set in Bedrock</geo:monumentFoundation>
+                <geo:foundationDepth>4.9</geo:foundationDepth>
+                <geo:markerDescription>Stainless Steel Plate</geo:markerDescription>
+                <geo:dateInstalled>2002-09-15Z</geo:dateInstalled>
+                <geo:geologicCharacteristic>Thin Bedrock of between 5-20m of</geo:geologicCharacteristic>
+                <geo:bedrockType>SANDSTONE</geo:bedrockType>
+                <geo:bedrockCondition>Firm, variably oxidised, variably cemented</geo:bedrockCondition>
+                <geo:fractureSpacing>No Fractures</geo:fractureSpacing>
+                <geo:faultZonesNearby>Non documented</geo:faultZonesNearby>
+                <geo:notes>antenna mounting plate fixed to 1.5m stainless steel pole. Pole is fixed to 0.6m diameter bluestone pillar The GPS antenna is located on top of a stainless steel pillar, which has been secured into the top of a bluestone pillar set in bedrock</geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Melbourne</geo:city>
+                <geo:state>Victoria</geo:state>
+                <geo:countryCodeISO codeSpace="urn:igs-org:gnss-country-code" codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS">AUS</geo:countryCodeISO>
+                <geo:tectonicPlate>Indian/Australian</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-4130636.106 2894953.089 -3890531.051</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-37.82941634 144.9753351 40.674</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes>The GPS is located at the old Melbourne Observatory, located in the Royal Melbourne Botanical Gardens</geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_1">
+            <geo:dateInserted>2002-10-29T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2006-01-23T23:59:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_2">
+            <geo:dateInserted>2006-01-24T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2007-06-20T23:59:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_3">
+            <geo:dateInserted>2007-06-21T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2008-11-16T23:59:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_4">
+            <geo:dateInserted>2008-11-17T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2009-07-23T23:59:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_5">
+            <geo:dateInserted>2009-07-24T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2010-05-03T04:30:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_6">
+            <geo:dateInserted>2010-05-03T04:30:00Z</geo:dateInserted>
+            <geo:dateDeleted>2010-08-05T00:00:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_7">
+            <geo:dateInserted>2010-08-05T00:00:00Z</geo:dateInserted>
+            <geo:dateDeleted>2010-10-08T03:15:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_8">
+            <geo:dateInserted>2010-10-08T03:15:00Z</geo:dateInserted>
+            <geo:dateDeleted>2013-06-24T02:00:00Z</geo:dateDeleted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver xlink:href="#GNSS_REC_9">
+            <geo:dateInserted>2013-06-24T02:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna xlink:href="#GNSS_ANT_1">
+            <geo:dateInserted>2002-10-21Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="SLT_1">
+                <geo:tiedMarkerName>Melbourne South PM 520</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>Local Height Control,</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber/>
+                <geo:tiedMarkerDOMESNumber/>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>31.8727</geo:dx>
+                    <geo:dy>15.4048</geo:dy>
+                    <geo:dz>-7.1087</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>Total Station</geo:surveyMethod>
+                <geo:dateMeasured>2012-06-07</geo:dateMeasured>
+                <geo:notes>Deep driven copper clad rod - 2.8m long</geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2012-06-07</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="SLT_2">
+                <geo:tiedMarkerName>Melbourne South PM 520/1</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>Local Horizontal Reference Control</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber/>
+                <geo:tiedMarkerDOMESNumber/>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>10.8675</geo:dx>
+                    <geo:dy>-58.0712</geo:dy>
+                    <geo:dz>-41.0895</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>Total Station</geo:surveyMethod>
+                <geo:dateMeasured>2012-06-07</geo:dateMeasured>
+                <geo:notes>Rivet in concrete kerb</geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2012-06-07</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="SLT_3">
+                <geo:tiedMarkerName>Melbourne South PM 436/1</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>Local Horizontal Reference Control</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber/>
+                <geo:tiedMarkerDOMESNumber/>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>28.5638</geo:dx>
+                    <geo:dy>-28.7831</geo:dy>
+                    <geo:dz>-37.5713</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>Total Station</geo:surveyMethod>
+                <geo:dateMeasured>2012-06-07</geo:dateMeasured>
+                <geo:notes>Rivet in concrete pit surround</geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2012-06-07</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="SLT_4">
+                <geo:tiedMarkerName>Melbourne South PM 436</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>Local Height Control,</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber/>
+                <geo:tiedMarkerDOMESNumber/>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>60.9038</geo:dx>
+                    <geo:dy>23.0815</geo:dy>
+                    <geo:dz>-30.4277</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>Total Station</geo:surveyMethod>
+                <geo:dateMeasured>2012-06-07</geo:dateMeasured>
+                <geo:notes>Deep driven copper clad rod - 2.8m long</geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2012-06-07</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="FREQSTANDARD_1">
+                <geo:standardType>QUARTZ</geo:standardType>
+                <geo:inputFrequency>5</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="FS_TP_1">
+                        <gml:beginPosition>2002-10-29Z</gml:beginPosition>
+                        <gml:endPosition indeterminatePosition="unknown"/>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes/>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2002-10-29Z</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:siteOwner gml:id="SO">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteOwner>
+        <geo:siteContact gml:id="SC_1">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteContact gml:id="SC_2">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Bob Twilley</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Technical Officer, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9066</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 413 604 180</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="SMDC">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:siteDataCenter gml:id="SDC_1">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteDataCenter>
+        <geo:siteDataCenter gml:id="SDC_2">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Bob Twilley</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Technical Officer, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9066</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 413 604 180</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteDataCenter>
+        <geo:siteDataSource gml:id="SDS_1">
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:positionName>
+                    <gco:CharacterString>Scientist A/g, Geodesy &amp; Seismic Monitoring Group</gco:CharacterString>
+                </gmd:positionName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteDataSource>
+    </geo:siteLog>
+    <!--  -->
+    <geo:Node gml:id="NODE_1">
+        <geo:aggregationType codeSpace="urn:ga-gov-au:egeodesy-node-aggregation-type">National Adjustment Weekly Solution</geo:aggregationType>
+        <gml:validTime>
+            <gml:TimePeriod gml:id="NODE_TP_1">
+                <gml:beginPosition>2013-11-04Z</gml:beginPosition>
+                <gml:endPosition indeterminatePosition="unknown"/>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:atSite xlink:href="#SITE_1"/>
+    </geo:Node>
+    <geo:PositionSource gml:id="ID_PS_1">
+        <gml:validTime>
+            <gml:TimePeriod gml:id="ID_PS_1_TP">
+                <gml:beginPosition>2015-01-11Z</gml:beginPosition>
+                <gml:end>
+                    <gml:TimeInstant gml:id="PS_1_ET">
+                        <gml:timePosition>2015-01-17Z</gml:timePosition>
+                    </gml:TimeInstant>
+                </gml:end>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:results>
+            <geo:adjustedPosition>
+                <geo:usesPosition xlink:href="ID_PTS_1"/>
+            </geo:adjustedPosition>
+        </geo:results>
+        <geo:associatedDocument>
+            <geo:Document gml:id="SINEX_1">
+                <geo:type>SINEX</geo:type>
+                <geo:createdDate>2015-03-04Z</geo:createdDate>
+                <geo:receivedDate/>
+                <geo:custodian xlink:href="#DrJohnDawsonGA"/>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="ftp://ftp.ga.gov.au/geodesy-outgoing/gnss/solutions/apref/apr18277.snx"
+                    />
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+        <geo:operation xlink:href="#ID_PEP_1"/>
+    </geo:PositionSource>
+    <geo:PositionSource gml:id="ID_PS_2">
+        <gml:validTime>
+            <gml:TimePeriod gml:id="ID_PS_2_TP">
+                <gml:beginPosition>2015-01-18Z</gml:beginPosition>
+                <gml:end>
+                    <gml:TimeInstant gml:id="PS_2_ET">
+                        <gml:timePosition>2015-01-24Z</gml:timePosition>
+                    </gml:TimeInstant>
+                </gml:end>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:results>
+            <geo:adjustedPosition>
+                <geo:usesPosition xlink:href="ID_PTS_1"/>
+            </geo:adjustedPosition>
+        </geo:results>
+        <geo:associatedDocument>
+            <geo:Document gml:id="SINEX_2">
+                <geo:type>SINEX</geo:type>
+                <geo:createdDate>2015-03-20Z</geo:createdDate>
+                <geo:receivedDate/>
+                <geo:custodian xlink:href="#DrJohnDawsonGA"/>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="ftp://ftp.ga.gov.au/geodesy-outgoing/gnss/solutions/apref/apr18287.snx"
+                    />
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+        <geo:operation xlink:href="#ID_PEP_1"/>
+    </geo:PositionSource>
+    <geo:PositionSource gml:id="ID_PS_3">
+        <gml:validTime>
+            <gml:TimePeriod gml:id="ID_PS_3_TP">
+                <gml:beginPosition>2015-01-25Z</gml:beginPosition>
+                <gml:end>
+                    <gml:TimeInstant gml:id="PS_3_ET">
+                        <gml:timePosition>2015-01-31Z</gml:timePosition>
+                    </gml:TimeInstant>
+                </gml:end>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:results>
+            <geo:adjustedPosition>
+                <geo:usesPosition xlink:href="ID_PTS_1"/>
+            </geo:adjustedPosition>
+        </geo:results>
+        <geo:associatedDocument>
+            <geo:Document gml:id="SINEX_3">
+                <geo:type>SINEX</geo:type>
+                <geo:createdDate>2015-04-01Z</geo:createdDate>
+                <geo:receivedDate/>
+                <geo:custodian xlink:href="#DrJohnDawsonGA"/>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="ftp://ftp.ga.gov.au/geodesy-outgoing/gnss/solutions/apref/apr18297.snx"
+                    />
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+        <geo:operation xlink:href="#ID_PEP_1"/>
+    </geo:PositionSource>
+    <geo:PositionSource gml:id="ID_PS_4">
+        <gml:validTime>
+            <gml:TimePeriod gml:id="ID_PS_4_TP">
+                <gml:beginPosition>2015-02-01Z</gml:beginPosition>
+                <gml:end>
+                    <gml:TimeInstant gml:id="PS_4_ET">
+                        <gml:timePosition>2015-02-07Z</gml:timePosition>
+                    </gml:TimeInstant>
+                </gml:end>
+            </gml:TimePeriod>
+        </gml:validTime>
+        <geo:results>
+            <geo:adjustedPosition>
+                <geo:usesPosition xlink:href="ID_PTS_1"/>
+            </geo:adjustedPosition>
+        </geo:results>
+        <geo:associatedDocument>
+            <geo:Document gml:id="SINEX_4">
+                <geo:type>SINEX</geo:type>
+                <geo:createdDate>2015-03-20Z</geo:createdDate>
+                <geo:receivedDate/>
+                <geo:custodian xlink:href="#DrJohnDawsonGA"/>
+                <geo:body>
+                    <geo:fileReference
+                        xlink:href="ftp://ftp.ga.gov.au/geodesy-outgoing/gnss/solutions/apref/apr18307.snx"
+                    />
+                </geo:body>
+            </geo:Document>
+        </geo:associatedDocument>
+        <geo:operation xlink:href="#ID_PEP_1"/>
+    </geo:PositionSource>
+    <geo:PositionEstimatorProcess gml:id="ID_PEP_1">
+        <gml:identifier codeSpace="urn:itrf.ensg.ign.fr"/>
+        <gml:scope/>
+        <geo:processStep>
+            <geo:description>Bernese</geo:description>
+        </geo:processStep>
+    </geo:PositionEstimatorProcess>
+    <geo:PositionTimeSeries gml:id="ID_PTS_1" srsName="http://www.opengis.net/gml/srs/epsg.xml#4938"
+        srsDimension="3">
+        <geo:atNode xlink:href="#NODE_1"/>
+        <geo:Status>
+            <geo:currentStatus>
+                <gml:validTime>
+                    <gml:TimeInstant gml:id="ID_PTS_STATUS_1">
+                        <gml:timePosition>2013-11-04Z</gml:timePosition>
+                    </gml:TimeInstant>
+                </gml:validTime>
+                <geo:statusCode codeSpace="">Authoritative</geo:statusCode>
+            </geo:currentStatus>
+        </geo:Status>
+        <geo:history>
+            <geo:PositionTimeSlice gml:id="ID_7">
+                <geo:coordinates uomLabels="m" axisLabels="X Y Z">-.413063656951996E+07
+                    0.289495312583357E+07 -.389053047150543E+07</geo:coordinates>
+                <gml:validTime xlink:href="#PS_1_ET"/>
+                <geo:hasVelocity>
+                    <geo:velocity uomLabels="mPyr" axisLabels="dX dY dZ">0.0 0.0 0.0</geo:velocity>
+                    <geo:VCV3D codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_velocity-uncertainty"
+                        uomLabels="m">0.01 0 0 0.01 0 0.01</geo:VCV3D>
+                </geo:hasVelocity>
+                <geo:VCV3D codeSpace="urn:ga-gov-au:egeodesy:vcv3d" uomLabels="m"
+                    axisLabels="sXX sXY sXZ sYY sYZ sZZ" confidence="1 sigma">2.04E-07 0 0 1.34E-07
+                    0 1.77E-07</geo:VCV3D>
+                <geo:NumericSingleQuality
+                    codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_positional-uncertainty"
+                    uomLabels="m">0.002154006</geo:NumericSingleQuality>
+                <geo:source xlink:href="#ID_PS_1"/>
+            </geo:PositionTimeSlice>
+            <geo:PositionTimeSlice gml:id="ID_8">
+                <geo:coordinates uomLabels="m" axisLabels="X Y Z">-.413063657063766E+07
+                    0.289495312799760E+07 -.389053047181324E+07</geo:coordinates>
+                <gml:validTime xlink:href="#PS_2_ET"/>
+                <geo:hasVelocity>
+                    <geo:velocity uomLabels="mPyr" axisLabels="dX dY dZ">0.0 0.0 0.0</geo:velocity>
+                    <geo:VCV3D codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_velocity-uncertainty"
+                        uomLabels="m">0.01 0 0 0.01 0 0.01</geo:VCV3D>
+                </geo:hasVelocity>
+                <geo:VCV3D codeSpace="urn:ga-gov-au:egeodesy:vcv3d" uomLabels="m"
+                    axisLabels="sXX sXY sXZ sYY sYZ sZZ" confidence="1 sigma">4.87E-08 0 0 3.81E-08
+                    0 4.44E-08</geo:VCV3D>
+                <geo:NumericSingleQuality
+                    codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_positional-uncertainty"
+                    uomLabels="m">0.00108692</geo:NumericSingleQuality>
+            </geo:PositionTimeSlice>
+            <geo:PositionTimeSlice gml:id="ID_9">
+                <geo:coordinates uomLabels="m" axisLabels="X Y Z">-.413063656959656E+07
+                    0.289495312557582E+07 -.389053046799322E+07</geo:coordinates>
+                <gml:validTime xlink:href="#PS_3_ET"/>
+                <geo:hasVelocity>
+                    <geo:velocity uomLabels="mPyr" axisLabels="dX dY dZ">0.0 0.0 0.0</geo:velocity>
+                    <geo:VCV3D codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_velocity-uncertainty"
+                        uomLabels="m">0.01 0 0 0.01 0 0.01</geo:VCV3D>
+                </geo:hasVelocity>
+                <geo:VCV3D codeSpace="urn:ga-gov-au:egeodesy:vcv3d" uomLabels="m"
+                    axisLabels="sXX sXY sXZ sYY sYZ sZZ" confidence="1 sigma">2.20E-07 0 0 1.44E-07
+                    0 1.84E-07</geo:VCV3D>
+                <geo:NumericSingleQuality
+                    codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_positional-uncertainty"
+                    uomLabels="m">2.2E-03</geo:NumericSingleQuality>
+            </geo:PositionTimeSlice>
+            <geo:PositionTimeSlice gml:id="ID_10">
+                <geo:coordinates uomLabels="m" axisLabels="X Y Z">-.413063657442620E+07
+                    0.289495312786955E+07 -.389053047117374E+07</geo:coordinates>
+                <gml:validTime xlink:href="#PS_4_ET"/>
+                <geo:hasVelocity>
+                    <geo:velocity uomLabels="mPyr" axisLabels="dX dY dZ">0.0 0.0 0.0</geo:velocity>
+                    <geo:VCV3D codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_velocity-uncertainty"
+                        uomLabels="m">0.01 0 0 0.01 0 0.01</geo:VCV3D>
+                </geo:hasVelocity>
+                <geo:VCV3D codeSpace="urn:ga-gov-au:egeodesy:vcv3d" uomLabels="m"
+                    axisLabels="sXX sXY sXZ sYY sYZ sZZ" confidence="1 sigma">2.99E-07 0 0 1.95E-07
+                    0 2.62E-07</geo:VCV3D>
+                <geo:NumericSingleQuality
+                    codeSpace="urn:xml-gov-au:icsm:egeodesy:sp1v20_positional-uncertainty"
+                    uomLabels="m">0.00260872</geo:NumericSingleQuality>
+            </geo:PositionTimeSlice>
+        </geo:history>
+    </geo:PositionTimeSeries>
+</geo:GeodesyML>

--- a/examples/0.6/MOBS.xml
+++ b/examples/0.6/MOBS.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <geo:GeodesyML gml:id="GEO_1" xmlns:gml="http://www.opengis.net/gml/3.2"
-    xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5"
+    xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xsi:schemaLocation="urn:xml-gov-au:icsm:egeodesy:0.5 ../schemas/geodesyML.xsd">
+    xsi:schemaLocation="urn:xml-gov-au:icsm:egeodesy:0.6 ../schemas/geodesyML.xsd">
     <!--
         @Name MOBS_SiteLog.xml
         @Author Laurence Davies

--- a/examples/0.6/bboo_20170223.xml
+++ b/examples/0.6/bboo_20170223.xml
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="BBOO00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="bboo_20170223.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Ryan Ruddick</geo:preparedBy>
+                <geo:datePrepared>2017-02-23</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Buckleboo</geo:siteName>
+                <geo:fourCharacterID>BBOO</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>59997M001</geo:iersDOMESNumber>
+                <geo:cdpNumber>NONE</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">PILLAR</geo:monumentDescription>
+                <geo:heightOfTheMonument>1.8</geo:heightOfTheMonument>
+                <geo:monumentFoundation>STEEL RODS / CONCRETE BLOCK</geo:monumentFoundation>
+                <geo:foundationDepth>0.3</geo:foundationDepth>
+                <geo:markerDescription>STAINLESS STEEL PLATE / THREADED SPIGOT</geo:markerDescription>
+                <geo:dateInstalled>2009-08-04</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type">BEDROCK</geo:geologicCharacteristic>
+                <geo:bedrockType></geo:bedrockType>
+                <geo:bedrockCondition></geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type"></geo:faultZonesNearby>
+                <geo:notes></geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Buckleboo</geo:city>
+                <geo:state>South Australia</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-3863895.1956 3723681.645 -3436457.3281</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-32.8103572889 136.058668739 288.7264</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes></geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:manufacturerSerialNumber>355418</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.50</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2009-08-05T02:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-05-03T01:30:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2009-08-05T02:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-2">
+                <geo:notes>ME upgrade due to GLONASS tracking problem</geo:notes>
+                <geo:manufacturerSerialNumber>355418</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.50 / 3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-05-03T01:30:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2011-05-06T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-05-03T01:30:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-3">
+                <geo:manufacturerSerialNumber>355418</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.10/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2011-05-06T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2011-08-24T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2011-05-06T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-4">
+                <geo:manufacturerSerialNumber>355418</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.20/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2011-08-25T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2014-07-09T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2011-08-25T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-5">
+                <geo:manufacturerSerialNumber>355418</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2014-07-09T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2016-11-07T06:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-6">
+                <geo:manufacturerSerialNumber>1705033</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GR30" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GR30</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO+GAL+BDS+QZSS</geo:satelliteSystem>
+                <geo:firmwareVersion>4.00.335/7.001</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2016-11-07T06:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2016-11-16T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2016-11-07T06:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-7">
+                <geo:manufacturerSerialNumber>1705033</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GR30" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GR30</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO+GAL+BDS+QZSS</geo:satelliteSystem>
+                <geo:firmwareVersion>4.02.386/7.002</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2016-11-16T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2017-02-23T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2016-11-16T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-8">
+                <geo:manufacturerSerialNumber>1705033</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GR30" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GR30</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO+GAL+BDS+QZSS</geo:satelliteSystem>
+                <geo:firmwareVersion>4.11.606/7.102</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2017-02-23T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2017-02-23T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>200547</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAT504GG SCIS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAT504GG      SCIS</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BPA</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">SCIS</geo:antennaRadomeType>
+                <geo:radomeSerialNumber>N/A</geo:radomeSerialNumber>
+                <geo:antennaCableType>RG214</geo:antennaCableType>
+                <geo:antennaCableLength>32.0</geo:antennaCableLength>
+                <geo:dateInstalled>2009-08-05T02:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2009-08-05T02:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="frequency-standard-1">
+                <geo:standardType codeSpace="urn:ga-gov-au:frequency-standard-type">QUARTZ/INTERNAL</geo:standardType>
+                <geo:inputFrequency>5.0</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="frequency-standard-1--time-period-1">
+                        <gml:beginPosition>2009-08-05</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2009-08-05</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:humiditySensor>
+            <geo:HumiditySensor gml:id="humidity-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:humidity-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:manufacturer>PAROSCIENTIFIC</geo:manufacturer>
+                <geo:serialNumber>DQ106788</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="humidity-sensor-1--time-period-1">
+                        <gml:beginPosition>2009-08-05</gml:beginPosition>
+                        <gml:endPosition>2016-11-07</gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-percentRelativeHumidity>2.0</geo:accuracy-percentRelativeHumidity>
+                <geo:aspiration>UNASPIRATED</geo:aspiration>
+            </geo:HumiditySensor>
+            <geo:dateInserted>2009-08-05</geo:dateInserted>
+        </geo:humiditySensor>
+        <geo:pressureSensor>
+            <geo:PressureSensor gml:id="pressure-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:pressure-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:manufacturer>PAROSCIENTIFIC</geo:manufacturer>
+                <geo:serialNumber>DQ106788</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="pressure-sensor-1--time-period-2">
+                        <gml:beginPosition>2009-08-05</gml:beginPosition>
+                        <gml:endPosition>2016-11-07</gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-hPa>0.1</geo:accuracy-hPa>
+            </geo:PressureSensor>
+            <geo:dateInserted>2009-08-05</geo:dateInserted>
+        </geo:pressureSensor>
+        <geo:temperatureSensor>
+            <geo:TemperatureSensor gml:id="temperature-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:temperature-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:manufacturer>PAROSCIENTIFIC</geo:manufacturer>
+                <geo:serialNumber>DQ106788</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="temperature-sensor-1--time-period-3">
+                        <gml:beginPosition>2009-08-05</gml:beginPosition>
+                        <gml:endPosition>2016-11-07</gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-degreesCelcius>0.5</geo:accuracy-degreesCelcius>
+                <geo:aspiration>UNASPIRATED</geo:aspiration>
+            </geo:TemperatureSensor>
+            <geo:dateInserted>2009-08-05</geo:dateInserted>
+        </geo:temperatureSensor>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString></gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString></gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9929</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>Geoscience Australia
+GPO Box 378
+Canberra  ACT  2601
+AUSTRALIA</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Ryan.Ruddick@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>GA (ftp.ga.gov.au)</geo:dataCenter>
+                <geo:dataCenter>Not Available</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap></geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>N</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>http://www.ga.gov.au</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/bboo_20170223.xml
+++ b/examples/0.6/bboo_20170223.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="BBOO00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="BBOO00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="bboo_20170223.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/0.6/bcus_20150709.xml
+++ b/examples/0.6/bcus_20150709.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="BCUS00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="bcus_20150709.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Ted Zhou</geo:preparedBy>
+                <geo:datePrepared>2015-07-09</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Bacchus Marsh 2</geo:siteName>
+                <geo:fourCharacterID>BCUS</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>AUM000223</geo:iersDOMESNumber>
+                <geo:cdpNumber>(A4)</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">STEEL MAST</geo:monumentDescription>
+                <geo:heightOfTheMonument>2.1</geo:heightOfTheMonument>
+                <geo:monumentFoundation>BUILDING ROOF</geo:monumentFoundation>
+                <geo:foundationDepth>0.0</geo:foundationDepth>
+                <geo:markerDescription>Stainless Steel Plate, Threaded SPIGOT</geo:markerDescription>
+                <geo:dateInstalled>2011-03-21T00:00:00Z</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type"></geo:geologicCharacteristic>
+                <geo:bedrockType></geo:bedrockType>
+                <geo:bedrockCondition></geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type"></geo:faultZonesNearby>
+                <geo:notes></geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Bacchus Marsh</geo:city>
+                <geo:state>Victoria</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-4111998.8967 2939332.7641 -3877182.5542</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-37.6768038639 144.442114992 112.491</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes>coords updated 29 June 2014 to Reg13</geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:notes>edited date removed</geo:notes>
+                <geo:manufacturerSerialNumber>353304</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.50/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>5.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2011-03-21T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2014-07-16T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2011-03-21T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-2">
+                <geo:notes>updated firmware</geo:notes>
+                <geo:manufacturerSerialNumber>353304</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>5.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2014-07-16T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2014-07-16T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>08090150</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAX1202GG NONE" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAX1202GG     NONE</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BAM</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">NONE</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType></geo:antennaCableType>
+                <geo:antennaCableLength xsi:nil="true"></geo:antennaCableLength>
+                <geo:dateInstalled>2011-03-21T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2011-03-21T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Hayden Asmussen</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Dept. of Environment &amp; Primary Industries</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(03) 8636 2374</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>(03) 8636 2813</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>Level 13, 570 Bourke St, Melbourne, VIC 3000</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Hayden.Asmussen@depi.vic.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>GPSnet Support</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Dept. of Environment &amp; Primary Industries</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>(03) 8636 2813</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>Level 13, 570 Bourke St, Melbourne, VIC 3000</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>GPSnet.support@depi.vic.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>http://gnss.vicpos.com.au</geo:dataCenter>
+                <geo:dataCenter>http://www.gpsnet.com.au</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap>Y</geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>Y</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>Y</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/bcus_20150709.xml
+++ b/examples/0.6/bcus_20150709.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="BCUS00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="BCUS00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="bcus_20150709.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/0.6/bdle_20150212.xml
+++ b/examples/0.6/bdle_20150212.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="BDLE00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="BDLE00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="bdle_20150212.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/0.6/bdle_20150212.xml
+++ b/examples/0.6/bdle_20150212.xml
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="BDLE00AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="bdle_20150212.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Alex Woods</geo:preparedBy>
+                <geo:datePrepared>2015-02-12</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Bairnsdale</geo:siteName>
+                <geo:fourCharacterID>BDLE</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>50196M001</geo:iersDOMESNumber>
+                <geo:cdpNumber>(A4)</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">PILLAR</geo:monumentDescription>
+                <geo:heightOfTheMonument>1.5</geo:heightOfTheMonument>
+                <geo:monumentFoundation>STEEL RODS / CONCRETE BLOCK</geo:monumentFoundation>
+                <geo:foundationDepth>0.5</geo:foundationDepth>
+                <geo:markerDescription>STAINLESS STEEL PLATE, THREADED SPIGOT</geo:markerDescription>
+                <geo:dateInstalled>2009-03-24</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type">BEDROCK</geo:geologicCharacteristic>
+                <geo:bedrockType>SEDIMENTARY</geo:bedrockType>
+                <geo:bedrockCondition>WEATHERED</geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type">NO</geo:faultZonesNearby>
+                <geo:notes></geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Bairnsdale</geo:city>
+                <geo:state>Victoria</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-4265653.14 2701218.722 -3884387.275</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-37.7586145611 147.656023153 126.048</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes></geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:manufacturerSerialNumber>353283</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.01</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2009-03-24T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2009-09-21T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2009-03-24T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-2">
+                <geo:manufacturerSerialNumber>353283</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.53</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2009-09-22T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-04-01T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2009-09-22T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-3">
+                <geo:manufacturerSerialNumber>353283</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.80</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-04-01T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-05-03T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-04-01T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-4">
+                <geo:notes>ME upgrade due to GLONASS tracking problem.</geo:notes>
+                <geo:manufacturerSerialNumber>353283</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.80/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-05-03T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2012-11-30T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-05-03T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-5">
+                <geo:manufacturerSerialNumber>1830274</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GR25" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GR25</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>2.61/6.111</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2012-11-30T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2014-12-09T05:30:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2012-11-30T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-6">
+                <geo:manufacturerSerialNumber>1830274</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GR25" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GR25</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>3.11.1639/6.403</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2014-12-09T05:30:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2014-12-09T05:30:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>200248</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAT504GG SCIS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAT504GG      SCIS</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BPA</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">SCIS</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType>Huber+Suhner</geo:antennaCableType>
+                <geo:antennaCableLength>30.0</geo:antennaCableLength>
+                <geo:dateInstalled>2009-03-24T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2009-03-24T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="local-tie-1">
+                <geo:tiedMarkerName>RM1</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>LOCAL CONTROL</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber>(A4)</geo:tiedMarkerCDPNumber>
+                <geo:tiedMarkerDOMESNumber>(A9)</geo:tiedMarkerDOMESNumber>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>0.0</geo:dx>
+                    <geo:dy>0.0</geo:dy>
+                    <geo:dz>0.0</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1.0</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>TRIANGULATION</geo:surveyMethod>
+                <geo:dateMeasured>2014-07-09T00:00:00Z</geo:dateMeasured>
+                <geo:notes></geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="local-tie-2">
+                <geo:tiedMarkerName>RM2</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>LOCAL CONTROL</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber>(A4)</geo:tiedMarkerCDPNumber>
+                <geo:tiedMarkerDOMESNumber>(A9)</geo:tiedMarkerDOMESNumber>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>0.0</geo:dx>
+                    <geo:dy>0.0</geo:dy>
+                    <geo:dz>0.0</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1.0</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>TRIANGULATION</geo:surveyMethod>
+                <geo:dateMeasured>2014-07-09T00:00:00Z</geo:dateMeasured>
+                <geo:notes></geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="local-tie-3">
+                <geo:tiedMarkerName>RM3</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>LOCAL CONTROL</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber>(A4)</geo:tiedMarkerCDPNumber>
+                <geo:tiedMarkerDOMESNumber>(A9)</geo:tiedMarkerDOMESNumber>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>0.0</geo:dx>
+                    <geo:dy>0.0</geo:dy>
+                    <geo:dz>0.0</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1.0</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>TRIANGULATION</geo:surveyMethod>
+                <geo:dateMeasured>2014-07-09T00:00:00Z</geo:dateMeasured>
+                <geo:notes></geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:surveyedLocalTie>
+            <geo:SurveyedLocalTie gml:id="local-tie-4">
+                <geo:tiedMarkerName>PILLAR</geo:tiedMarkerName>
+                <geo:tiedMarkerUsage>LOCAL CONTROL</geo:tiedMarkerUsage>
+                <geo:tiedMarkerCDPNumber>(A4)</geo:tiedMarkerCDPNumber>
+                <geo:tiedMarkerDOMESNumber>(A9)</geo:tiedMarkerDOMESNumber>
+                <geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                    <geo:dx>0.0</geo:dx>
+                    <geo:dy>0.0</geo:dy>
+                    <geo:dz>0.0</geo:dz>
+                </geo:differentialComponentsGNSSMarkerToTiedMonumentITRS>
+                <geo:localSiteTiesAccuracy>1.0</geo:localSiteTiesAccuracy>
+                <geo:surveyMethod>TRIANGULATION</geo:surveyMethod>
+                <geo:dateMeasured>2014-07-09T00:00:00Z</geo:dateMeasured>
+                <geo:notes></geo:notes>
+            </geo:SurveyedLocalTie>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:surveyedLocalTie>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="frequency-standard-1">
+                <geo:standardType codeSpace="urn:ga-gov-au:frequency-standard-type">QUARTZ/INTERNAL</geo:standardType>
+                <geo:inputFrequency>5.0</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="frequency-standard-1--time-period-1">
+                        <gml:beginPosition>2009-03-24</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2009-03-24</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:humiditySensor>
+            <geo:HumiditySensor gml:id="humidity-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:humidity-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:notes>(multiple lines)</geo:notes>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>107124</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="humidity-sensor-1--time-period-1">
+                        <gml:beginPosition>2009-03-24</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-percentRelativeHumidity>2.0</geo:accuracy-percentRelativeHumidity>
+                <geo:aspiration>UNASPIRATED</geo:aspiration>
+            </geo:HumiditySensor>
+            <geo:dateInserted>2009-03-24</geo:dateInserted>
+        </geo:humiditySensor>
+        <geo:pressureSensor>
+            <geo:PressureSensor gml:id="pressure-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:pressure-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>107124</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.074</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="pressure-sensor-1--time-period-2">
+                        <gml:beginPosition>2009-03-24</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-hPa>0.08</geo:accuracy-hPa>
+            </geo:PressureSensor>
+            <geo:dateInserted>2009-03-24</geo:dateInserted>
+        </geo:pressureSensor>
+        <geo:temperatureSensor>
+            <geo:TemperatureSensor gml:id="temperature-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:temperature-sensor-type">PAROSCIENTIFIC MET4</geo:type>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>107124</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="temperature-sensor-1--time-period-3">
+                        <gml:beginPosition>2009-03-24</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-degreesCelcius>0.5</geo:accuracy-degreesCelcius>
+                <geo:aspiration>UNASPIRATED</geo:aspiration>
+            </geo:TemperatureSensor>
+            <geo:dateInserted>2009-03-24</geo:dateInserted>
+        </geo:temperatureSensor>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Hayden Asmussen</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Dept. of Environment &amp; Primary Industries</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>(03) 8636 2374</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>(03) 8636 2813</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>Level 13, 570 Bourke St, Melbourne, VIC 3000</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Hayden.Asmussen@depi.vic.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Bob Twilley</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9066</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString>+61 2 6249 9929</gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>Geoscience Australia
+GPO Box 378
+Canberra ACT 2601
+AUSTRALIA</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>Bob.Twilley@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>GA (ftp.ga.gov.au)</geo:dataCenter>
+                <geo:dataCenter>http://www.gpsnet.com.au</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap>Y</geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>Y</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>Y</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/yar3_20140709.xml
+++ b/examples/0.6/yar3_20140709.xml
@@ -1,0 +1,446 @@
+<?xml version="1.0" encoding="utf-8"?>
+<geo:GeodesyML gml:id="YAR300AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <geo:siteLog gml:id="yar3_20140709.log">
+        <geo:formInformation>
+            <geo:FormInformation gml:id="form-info">
+                <geo:preparedBy>Ted Zhou</geo:preparedBy>
+                <geo:datePrepared>2014-07-09</geo:datePrepared>
+                <geo:reportType>UPDATE</geo:reportType>
+            </geo:FormInformation>
+        </geo:formInformation>
+        <geo:siteIdentification>
+            <geo:SiteIdentification gml:id="site-identification">
+                <geo:siteName>Yarragadee</geo:siteName>
+                <geo:fourCharacterID>YAR3</geo:fourCharacterID>
+                <geo:monumentInscription></geo:monumentInscription>
+                <geo:iersDOMESNumber>50107M008</geo:iersDOMESNumber>
+                <geo:cdpNumber>NONE</geo:cdpNumber>
+                <geo:monumentDescription codeSpace="urn:ga-gov-au:monument-description-type">PILLAR</geo:monumentDescription>
+                <geo:heightOfTheMonument>1.5</geo:heightOfTheMonument>
+                <geo:monumentFoundation>CONCRETE BLOCK</geo:monumentFoundation>
+                <geo:markerDescription>Stainless Steel Plate</geo:markerDescription>
+                <geo:dateInstalled>2007-06-01T00:00:00Z</geo:dateInstalled>
+                <geo:geologicCharacteristic codeSpace="urn:ga-gov-au:geologic-characteristic-type"></geo:geologicCharacteristic>
+                <geo:bedrockType>SEDIMENTARY</geo:bedrockType>
+                <geo:bedrockCondition></geo:bedrockCondition>
+                <geo:fractureSpacing></geo:fractureSpacing>
+                <geo:faultZonesNearby codeSpace="urn:ga-gov-au:fault-zones-type">NO</geo:faultZonesNearby>
+                <geo:notes>Jurassic Yaragadee Formation; sandstone, siltstone, shale. The terrain is covered by low scrub. The site is on the edge of an escarpment running northeast from which a flat plateau extends towards the north. Geological information from &quot;NASA Space Geodesy Program Memorandum 4482&quot; p631.</geo:notes>
+            </geo:SiteIdentification>
+        </geo:siteIdentification>
+        <geo:siteLocation>
+            <geo:SiteLocation gml:id="site-location">
+                <geo:city>Yarragadee</geo:city>
+                <geo:state>Western Australia</geo:state>
+                <geo:countryCodeISO codeList="http://xml.gov.au/icsm/geodesyml/codelists/country-codes-codelist.xml#GeodesyML_CountryCode" codeListValue="AUS" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">Australia</geo:countryCodeISO>
+                <geo:tectonicPlate codeSpace="urn:ga-gov-au:plate-type">AUSTRALIAN</geo:tectonicPlate>
+                <geo:approximatePositionITRF>
+                    <geo:cartesianPosition>
+                        <gml:Point gml:id="itrf_cartesian">
+                            <gml:pos srsName="EPSG:7789">-2389042.6217 5043313.558 -3078525.7908</gml:pos>
+                        </gml:Point>
+                    </geo:cartesianPosition>
+                    <geo:geodeticPosition>
+                        <gml:Point gml:id="itrf_geodetic">
+                            <gml:pos srsName="EPSG:7912">-29.0465009917 115.347146686 242.6741</gml:pos>
+                        </gml:Point>
+                    </geo:geodeticPosition>
+                </geo:approximatePositionITRF>
+                <geo:notes>The site is located on the west coast
+    Australia, 53 miles east southeast of
+    Geraldtown and 218 miles north of Perth.
+    Site description information from &quot;NASA Space
+    Geodesy Program
+    Tech. Memorandum 4482&quot; p631.</geo:notes>
+            </geo:SiteLocation>
+        </geo:siteLocation>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-1">
+                <geo:manufacturerSerialNumber>351926</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>5.10</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2007-06-01T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2008-05-08T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2007-06-01T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-2">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>5.62</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2008-05-09T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2008-08-20T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2008-05-09T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-3">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>6.00</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2008-08-21T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2009-07-23T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2008-08-21T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-4">
+                <geo:notes>The tracking was changed from C2 or P2, to
+P2 only at 2009-07-31T00:00Z</geo:notes>
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.50</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2009-07-24T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-05-03T03:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2009-07-24T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-5">
+                <geo:notes>ME upgrade due to GLONASS tracking problems.</geo:notes>
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>7.50</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-05-03T03:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-08-24T01:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-05-03T03:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-6">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.00/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-08-24T01:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2010-10-15T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-08-24T01:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-7">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.01/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2010-10-15T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2011-08-24T23:59:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2010-10-15T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-8">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.20/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2011-08-25T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2013-03-26T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2011-08-25T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-9">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.51/3.019</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2013-03-26T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2014-07-09T00:00:00Z</geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2013-03-26T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssReceiver>
+            <geo:GnssReceiver gml:id="gnss-receiver-10">
+                <geo:manufacturerSerialNumber>355805</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSReceiverTypeCode" codeListValue="LEICA GRX1200GGPRO" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEICA GRX1200GGPRO</geo:igsModelCode>
+                <geo:satelliteSystem>GPS+GLO</geo:satelliteSystem>
+                <geo:firmwareVersion>8.71/3.822</geo:firmwareVersion>
+                <geo:elevationCutoffSetting>0.0</geo:elevationCutoffSetting>
+                <geo:dateInstalled>2014-07-09T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+                <geo:temperatureStabilization xsi:nil="true"></geo:temperatureStabilization>
+            </geo:GnssReceiver>
+            <geo:dateInserted>2014-07-09T00:00:00Z</geo:dateInserted>
+        </geo:gnssReceiver>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-1">
+                <geo:manufacturerSerialNumber>103320</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAT504 NONE" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAT504        NONE</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BPA</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.0035</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">NONE</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType>CNT-400 50 Ohm</geo:antennaCableType>
+                <geo:antennaCableLength>70.0</geo:antennaCableLength>
+                <geo:dateInstalled>2007-06-01T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved>2008-12-04T23:59:00Z</geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2007-06-01T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:gnssAntenna>
+            <geo:GnssAntenna gml:id="gnss-antenna-2">
+                <geo:manufacturerSerialNumber>08360001</geo:manufacturerSerialNumber>
+                <geo:igsModelCode codeList="http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml#GeodesyML_GNSSAntennaTypeCode" codeListValue="LEIAR25 NONE" codeSpace="urn:xml-gov-au:icsm:egeodesy:0.5">LEIAR25         NONE</geo:igsModelCode>
+                <geo:antennaReferencePoint codeSpace="urn:ga-gov-au:antenna-reference-point-type">BPA</geo:antennaReferencePoint>
+                <geo:marker-arpUpEcc.>0.004</geo:marker-arpUpEcc.>
+                <geo:marker-arpNorthEcc.>0.0</geo:marker-arpNorthEcc.>
+                <geo:marker-arpEastEcc.>0.0</geo:marker-arpEastEcc.>
+                <geo:alignmentFromTrueNorth>0.0</geo:alignmentFromTrueNorth>
+                <geo:antennaRadomeType codeSpace="urn:igs-org:gnss-radome-model-code">NONE</geo:antennaRadomeType>
+                <geo:radomeSerialNumber></geo:radomeSerialNumber>
+                <geo:antennaCableType>CNT-400 50 Ohm</geo:antennaCableType>
+                <geo:antennaCableLength>70.0</geo:antennaCableLength>
+                <geo:dateInstalled>2008-12-05T00:00:00Z</geo:dateInstalled>
+                <geo:dateRemoved></geo:dateRemoved>
+            </geo:GnssAntenna>
+            <geo:dateInserted>2008-12-05T00:00:00Z</geo:dateInserted>
+        </geo:gnssAntenna>
+        <geo:frequencyStandard>
+            <geo:FrequencyStandard gml:id="frequency-standard-1">
+                <geo:standardType codeSpace="urn:ga-gov-au:frequency-standard-type">INTERNAL</geo:standardType>
+                <geo:inputFrequency>0.0</geo:inputFrequency>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="frequency-standard-1--time-period-1">
+                        <gml:beginPosition>2007-06-01</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:FrequencyStandard>
+            <geo:dateInserted>2007-06-01</geo:dateInserted>
+        </geo:frequencyStandard>
+        <geo:collocationInformation>
+            <geo:CollocationInformation gml:id="instrumentation-type-1">
+                <geo:instrumentationType codeSpace="urn:ga-gov-au:instrumentation-type">SLR MOBLAS-5</geo:instrumentationType>
+                <geo:status codeSpace="urn:ga-gov-au:status-type">PERMANENT</geo:status>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="instrumentation-type-1--time-period-2">
+                        <gml:beginPosition>1979-07-01</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes></geo:notes>
+            </geo:CollocationInformation>
+            <geo:dateInserted>1979-07-01</geo:dateInserted>
+        </geo:collocationInformation>
+        <geo:collocationInformation>
+            <geo:CollocationInformation gml:id="instrumentation-type-2">
+                <geo:instrumentationType codeSpace="urn:ga-gov-au:instrumentation-type">DORIS</geo:instrumentationType>
+                <geo:status codeSpace="urn:ga-gov-au:status-type">PERMANENT</geo:status>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="instrumentation-type-2--time-period-3">
+                        <gml:beginPosition>1992-09-14</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:notes>Alcatel antenna (type A)</geo:notes>
+            </geo:CollocationInformation>
+            <geo:dateInserted>1992-09-14</geo:dateInserted>
+        </geo:collocationInformation>
+        <geo:humiditySensor>
+            <geo:HumiditySensor gml:id="humidity-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:humidity-sensor-type">PAROSCIENTIFIC MET3A</geo:type>
+                <geo:notes>unconfirmed height diff to ant</geo:notes>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>DQ101678</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="humidity-sensor-1--time-period-1">
+                        <gml:beginPosition>2008-06-09</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-percentRelativeHumidity>2.0</geo:accuracy-percentRelativeHumidity>
+                <geo:aspiration>FAN</geo:aspiration>
+            </geo:HumiditySensor>
+            <geo:dateInserted>2008-06-09</geo:dateInserted>
+        </geo:humiditySensor>
+        <geo:pressureSensor>
+            <geo:PressureSensor gml:id="pressure-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:pressure-sensor-type">PAROSCIENTIFIC MET3A</geo:type>
+                <geo:notes>unconfirmed height diff to ant</geo:notes>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>DQ101678</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="pressure-sensor-1--time-period-2">
+                        <gml:beginPosition>2008-06-09</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-hPa>0.1</geo:accuracy-hPa>
+            </geo:PressureSensor>
+            <geo:dateInserted>2008-06-09</geo:dateInserted>
+        </geo:pressureSensor>
+        <geo:temperatureSensor>
+            <geo:TemperatureSensor gml:id="temperature-sensor-1">
+                <geo:type codeSpace="urn:ga-gov-au:temperature-sensor-type">PAROSCIENTIFIC MET3A</geo:type>
+                <geo:notes>unconfirmed height diff to ant</geo:notes>
+                <geo:manufacturer>Paroscientific</geo:manufacturer>
+                <geo:serialNumber>DQ101678</geo:serialNumber>
+                <geo:heightDiffToAntenna>0.0</geo:heightDiffToAntenna>
+                <geo:calibrationDate></geo:calibrationDate>
+                <gml:validTime>
+                    <gml:TimePeriod gml:id="temperature-sensor-1--time-period-3">
+                        <gml:beginPosition>2008-06-09</gml:beginPosition>
+                        <gml:endPosition></gml:endPosition>
+                    </gml:TimePeriod>
+                </gml:validTime>
+                <geo:dataSamplingInterval>30.0</geo:dataSamplingInterval>
+                <geo:accuracy-degreesCelcius>0.5</geo:accuracy-degreesCelcius>
+                <geo:aspiration>FAN</geo:aspiration>
+            </geo:TemperatureSensor>
+            <geo:dateInserted>2008-06-09</geo:dateInserted>
+        </geo:temperatureSensor>
+        <geo:siteContact gml:id="agency-1">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Ryan Ruddick</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9426</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378
+Canberra  ACT  2601
+AUSTRALIA</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>geodesy@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteContact>
+        <geo:siteMetadataCustodian gml:id="agency-2">
+            <gmd:MD_SecurityConstraints>
+                <gmd:classification gco:nilReason="missing"/>
+            </gmd:MD_SecurityConstraints>
+            <gmd:CI_ResponsibleParty>
+                <gmd:individualName>
+                    <gco:CharacterString>Nicholas Brown</gco:CharacterString>
+                </gmd:individualName>
+                <gmd:organisationName>
+                    <gco:CharacterString>Geoscience Australia</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                    <gmd:CI_Contact>
+                        <gmd:phone>
+                            <gmd:CI_Telephone>
+                                <gmd:voice>
+                                    <gco:CharacterString>+61 2 6249 9831</gco:CharacterString>
+                                </gmd:voice>
+                                <gmd:facsimile>
+                                    <gco:CharacterString></gco:CharacterString>
+                                </gmd:facsimile>
+                            </gmd:CI_Telephone>
+                        </gmd:phone>
+                        <gmd:address>
+                            <gmd:CI_Address>
+                                <gmd:deliveryPoint>
+                                    <gco:CharacterString>GPO Box 378
+Canberra  ACT  2601
+AUSTRALIA</gco:CharacterString>
+                                </gmd:deliveryPoint>
+                                <gmd:city>
+                                    <gco:CharacterString>Canberra</gco:CharacterString>
+                                </gmd:city>
+                                <gmd:postalCode>
+                                    <gco:CharacterString>2601</gco:CharacterString>
+                                </gmd:postalCode>
+                                <gmd:country>
+                                    <gco:CharacterString>Australia</gco:CharacterString>
+                                </gmd:country>
+                                <gmd:electronicMailAddress>
+                                    <gco:CharacterString>geodesy@ga.gov.au</gco:CharacterString>
+                                </gmd:electronicMailAddress>
+                            </gmd:CI_Address>
+                        </gmd:address>
+                    </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"></gmd:CI_RoleCode>
+                </gmd:role>
+            </gmd:CI_ResponsibleParty>
+        </geo:siteMetadataCustodian>
+        <geo:moreInformation>
+            <geo:MoreInformation gml:id="more-info">
+                <geo:dataCenter>GA</geo:dataCenter>
+                <geo:dataCenter>CDDIS</geo:dataCenter>
+                <geo:urlForMoreInformation></geo:urlForMoreInformation>
+                <geo:siteMap>Y</geo:siteMap>
+                <geo:siteDiagram>Y</geo:siteDiagram>
+                <geo:horizonMask>Y</geo:horizonMask>
+                <geo:monumentDescription>Y</geo:monumentDescription>
+                <geo:sitePictures>Y</geo:sitePictures>
+                <geo:notes></geo:notes>
+                <geo:antennaGraphicsWithDimensions></geo:antennaGraphicsWithDimensions>
+                <geo:insertTextGraphicFromAntenna></geo:insertTextGraphicFromAntenna>
+                <geo:DOI codeSpace="urn:ga-gov-au:self.moreInformation-type">TODO</geo:DOI>
+            </geo:MoreInformation>
+        </geo:moreInformation>
+    </geo:siteLog>
+</geo:GeodesyML>

--- a/examples/0.6/yar3_20140709.xml
+++ b/examples/0.6/yar3_20140709.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<geo:GeodesyML gml:id="YAR300AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<geo:GeodesyML gml:id="YAR300AUS" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <geo:siteLog gml:id="yar3_20140709.log">
         <geo:formInformation>
             <geo:FormInformation gml:id="form-info">

--- a/examples/validate.sh
+++ b/examples/validate.sh
@@ -6,7 +6,7 @@ repositoryRoot=$(readlink -f "$(dirname "$0")/..")
 schemer=$repositoryRoot/tools/xml-schemer/bin/schemer.sh
 schematronValidate=$repositoryRoot/tools/schematron/schematronValidate.sh
 
-versions=("0.4" "0.5")
+versions=("0.4" "0.5" "0.6")
 
 outcome=0
 

--- a/schemas/catalog.xml
+++ b/schemas/catalog.xml
@@ -22,6 +22,10 @@
             rewritePrefix="geodesyml/0.5/"/>
 
     <rewriteSystem
+            systemIdStartString="urn:xml-gov-au:icsm:egeodesy:0.6"
+            rewritePrefix="geodesyml/0.6/"/>
+
+    <rewriteSystem
             systemIdStartString="http://www.isotc211.org/2005/"
             rewritePrefix="third-party/iso-19139-20070417/"/>
 

--- a/schemas/geodesyml/0.6/commonTypes.xsd
+++ b/schemas/geodesyml/0.6/commonTypes.xsd
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gco="http://www.isotc211.org/2005/gco" >
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gco/gco.xsd"/>
+    <include schemaLocation="document.xsd"/>
+    <!--  -->
+    <group name="RemarksGroup">
+        <annotation>
+            <documentation>A convenience group. This allows an application schema developer to include remarks and associated documents in a standard fashion.</documentation>
+        </annotation>
+        <sequence>
+            <element minOccurs="0" name="notes" type="string"/>
+            <element maxOccurs="unbounded" minOccurs="0" name="associatedDocument" type="geo:DocumentPropertyType"/>
+            <element minOccurs="0" name="extension" type="anyType"/>
+        </sequence>
+    </group>
+    <!-- Change tracking group -->
+    <group name="ChangeTracking">
+        <annotation>
+            <documentation>A convenience group to log changes made to each meta-data block.</documentation>
+        </annotation>
+        <sequence>
+            <sequence>
+                <element name="dateInserted" type="gml:TimePositionType"/>
+                <element minOccurs="0" name="dateDeleted" type="gml:TimePositionType"/>
+                <element minOccurs="0" name="deletedReason" type="string"/>
+            </sequence>
+        </sequence>
+    </group>
+    <!--  -->
+    <attributeGroup name="RequiredSRSReferenceGroup">
+        <annotation>
+            <documentation>The attribute group SRSReferenceGroup is a required reference to the CRS used by this geometry, with optional additional information to simplify the processing of the coordinates when a more complete definition of the CRS is not needed.
+                In general the attribute srsName points to a CRS instance of gml:AbstractCoordinateReferenceSystem. For well-known references it is not required that the CRS description exists at the location the URI points to. 
+                If no srsName attribute is given, the CRS shall be specified as part of the larger context this geometry element is part of.</documentation>
+        </annotation>
+        <attribute name="srsName" type="anyURI" use="required"/>
+        <attribute name="srsDimension" type="positiveInteger"/>
+        <attributeGroup ref="gml:SRSInformationGroup"/>
+    </attributeGroup>
+    <!--  -->
+    <group name="TimeSliceProperties">
+        <annotation>
+            <documentation/>
+        </annotation>
+        <sequence>
+            <element ref="gml:validTime"/>
+            <element minOccurs="0" ref="gml:dataSource"/>
+        </sequence>
+    </group>
+    <!--  -->
+    <complexType name="DynamicFeatureType">
+        <complexContent>
+            <restriction base="gml:DynamicFeatureType">
+                <sequence>
+                    <sequence>
+                        <group ref="gml:StandardObjectProperties"/>
+                    </sequence>
+                    <sequence>
+                        <element minOccurs="0" ref="gml:boundedBy"/>
+                        <element minOccurs="0" ref="gml:location"/>
+                    </sequence>
+                    <sequence>
+                        <element minOccurs="0" ref="gml:validTime"/>
+                        <element minOccurs="0" ref="gml:dataSource"/>
+                        <element minOccurs="0" ref="gml:dataSourceReference"/>
+                    </sequence>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="DynamicFeature" substitutionGroup="gml:AbstractFeature" type="geo:DynamicFeatureType">
+        <annotation>
+            <documentation>Restriction of the gml:DynamicFeatureType. Removes gml:history and relies upon the extending type to implement a history element that restricts child types to those allowed by the class model.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="InstrumentPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Instrument"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractTimeSlice" substitutionGroup="gml:AbstractFeature" type="geo:AbstractTimeSliceType">
+        <annotation>
+            <documentation>Mimics the gml:AbstractTimeSlice element but extends gml:AbstractFeatureType instead of gml:AbstractGMLType. The purpose of making this distinction is to ensure better access to a wider variety of WFS solutions that use the gml:AbstractFeature/gml:Location element for visualisation. 
+            </documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="AbstractTimeSliceType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <group ref="geo:TimeSliceProperties"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="Instrument" substitutionGroup="gml:AbstractGML" type="geo:InstrumentType"/>
+    <!--  -->
+    <complexType name="InstrumentType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element minOccurs="0" name="type" type="gml:CodeType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType final="#all" name="countryCodeType">
+        <annotation>
+            <documentation xml:lang="en">
+                Three-letter country code (ISO ISO 3166-1 alpha-3, https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gco:CodeListValue_Type"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/commonTypes.xsd
+++ b/schemas/geodesyml/0.6/commonTypes.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gco="http://www.isotc211.org/2005/gco" >
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gco="http://www.isotc211.org/2005/gco" >
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/contact.xsd
+++ b/schemas/geodesyml/0.6/contact.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5"  xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gco/gco.xsd"/>
+    <annotation>
+        <documentation>
+        </documentation>
+    </annotation>
+    <complexType name="agencyPropertyType">
+        <annotation>
+            <documentation>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element minOccurs="0" ref="gmd:MD_SecurityConstraints"/>
+                    <element ref="gmd:CI_ResponsibleParty"/>
+                </sequence>
+                <attributeGroup ref="gml:AssociationAttributeGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/contact.xsd
+++ b/schemas/geodesyml/0.6/contact.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5"  xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6"  xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
     <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gco/gco.xsd"/>

--- a/schemas/geodesyml/0.6/dataStreams.xsd
+++ b/schemas/geodesyml/0.6/dataStreams.xsd
@@ -1,0 +1,129 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011 (http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/dataStreams/2011/dataStreams.xsd)</p>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Replaced schema enumerations with GML code lists</li>
+                <li>Added global dataStreams element and dataStreamPropertyType as per GML property-by-reference convention</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <include schemaLocation="contact.xsd">
+        <annotation>
+            <documentation>
+       Import components from the "contact.xsd" schema which resides in
+       the "http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/contact/2004" namespace.
+     </documentation>
+        </annotation>
+    </include>
+    <simpleType name="ipv4AddressType">
+        <annotation>
+            <documentation>
+      An IP Version 4 address.
+    </documentation>
+        </annotation>
+        <restriction base="string">
+            <pattern value="\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}"/>
+        </restriction>
+    </simpleType>
+    <simpleType name="ipv6AddressType">
+        <annotation>
+            <documentation>
+      An IP Version 6 address.
+    </documentation>
+        </annotation>
+        <restriction base="string">
+            <pattern value="([A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}"/>
+        </restriction>
+    </simpleType>
+    <simpleType name="ipAddressType">
+        <union memberTypes="geo:ipv4AddressType geo:ipv6AddressType"/>
+    </simpleType>
+    <simpleType name="dataFormatType">
+        <restriction base="token">
+            <enumeration value="RTCM_2"/>
+            <enumeration value="RTCM_2.2"/>
+            <enumeration value="RTCM_2.3"/>
+            <enumeration value="RTCM_3.0"/>
+            <enumeration value="RTCM_3.1"/>
+            <enumeration value="RYO"/>
+            <enumeration value="RYO_1.0"/>
+            <enumeration value="RYO_2.0"/>
+            <enumeration value="CMR"/>
+            <enumeration value="CMR+"/>
+            <enumeration value="RAW"/>
+        </restriction>
+    </simpleType>
+    <complexType name="ntripMountType">
+        <sequence>
+            <element minOccurs="0" name="mountPoint" type="token"/>
+            <element minOccurs="0" name="sourceID" type="string"/>
+            <element minOccurs="0" name="countryCode" type="token"/>
+            <element minOccurs="0" name="network" type="token"/>
+            <element minOccurs="0" name="allowConnections" type="boolean"/>
+            <element minOccurs="0" name="requireAuthentication" type="boolean"/>
+            <element minOccurs="0" name="encryption" type="boolean"/>
+            <element minOccurs="0" name="feesApply" type="boolean"/>
+            <element minOccurs="0" name="bitrate" type="double"/>
+            <element minOccurs="0" name="carrierPhase" type="token"/>
+            <element minOccurs="0" name="navSystem" type="token"/>
+            <element minOccurs="0" name="nmea" type="string"/>
+            <element minOccurs="0" name="solution" type="string"/>
+        </sequence>
+    </complexType>
+    <complexType name="ntripMountsType">
+        <sequence>
+            <element maxOccurs="unbounded" name="ntripMount" type="geo:ntripMountType"/>
+        </sequence>
+    </complexType>
+    <complexType name="baseDataStreamType">
+        <sequence>
+            <choice>
+                <element name="hostname" type="string"/>
+                <element name="ipAddress" type="geo:ipAddressType"/>
+            </choice>
+            <element name="port" type="positiveInteger"/>
+            <element name="sampInterval" type="double"/>
+            <!-- TODO: use gco code list values -->
+            <element name="dataFormat" type="gml:CodeType"/>
+            <element minOccurs="0" name="ntripMounts" type="geo:ntripMountsType"/>
+            <element minOccurs="0" name="startDate" type="date"/>
+        </sequence>
+    </complexType>
+    <complexType name="siteStreamType">
+        <sequence>
+            <element minOccurs="0" name="agency" type="geo:agencyPropertyType"/>
+            <element minOccurs="0" name="dataStream" type="geo:baseDataStreamType"/>
+        </sequence>
+    </complexType>
+    <complexType name="publishedStreamType">
+        <sequence>
+            <element minOccurs="0" name="agency" type="geo:agencyPropertyType"/>
+            <element maxOccurs="unbounded" minOccurs="0" name="dataStream" type="geo:baseDataStreamType"/>
+        </sequence>
+    </complexType>
+    <complexType name="dataStreamType">
+        <sequence>
+            <element minOccurs="0" name="siteStream" type="geo:siteStreamType"/>
+            <element minOccurs="0" name="publishedStream" type="geo:publishedStreamType"/>
+            <element minOccurs="0" name="notes" type="string"/>
+        </sequence>
+    </complexType>
+    <!--  Global dataStreams element -->
+    <element name="dataStream" type="geo:dataStreamType"/>
+    <!-- Property type -->
+    <complexType name="dataStreamPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:dataStream"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/dataStreams.xsd
+++ b/schemas/geodesyml/0.6/dataStreams.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <annotation>
         <documentation>

--- a/schemas/geodesyml/0.6/document.xsd
+++ b/schemas/geodesyml/0.6/document.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <!--  -->
+    <complexType name="DocumentPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Document"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Document" substitutionGroup="gml:AbstractFeature" type="geo:DocumentType"/>
+    <!--  -->
+    <complexType name="DocumentType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="type" type="gml:CodeType">
+                        <annotation>
+                            <documentation>Type of document.</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" name="createdDate" type="gml:TimePositionType"/>
+                    <element minOccurs="0" name="receivedDate" type="gml:TimePositionType"/>
+                    <element minOccurs="0" name="custodian" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element minOccurs="0" name="remarks" type="string"/>
+                    <element minOccurs="0" name="body">
+                        <complexType>
+                            <choice>
+                                <element name="fileReference" type="gml:ReferenceType"/>
+                                <element name="content">
+                                    <complexType>
+                                        <simpleContent>
+                                            <extension base="string">
+                                                <attribute default="none" name="encoding" type="geo:EncodingType"/>
+                                            </extension>
+                                        </simpleContent>
+                                    </complexType>
+                                </element>
+                                <any namespace="##other"/>
+                            </choice>
+                            <attribute name="format" type="string"/>
+                        </complexType>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <simpleType name="EncodingType">
+        <restriction base="string">
+            <enumeration value="none"/>
+            <enumeration value="base64"/>
+        </restriction>
+    </simpleType>
+</schema>

--- a/schemas/geodesyml/0.6/document.xsd
+++ b/schemas/geodesyml/0.6/document.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/equipment.xsd
+++ b/schemas/geodesyml/0.6/equipment.xsd
@@ -1,0 +1,427 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="geodeticEquipment.xsd"/>
+    <include schemaLocation="fieldMeasurement.xsd"/>
+    <include schemaLocation="measurement.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011</p>
+            <ul>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/antenna.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/baseEquipmentLib.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/collocationInformation.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/frequencyStandard.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/humiditySensor.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/otherInstrumentation.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/pressureSensor.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/receiver.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/surveyedLocalTies.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/temperatureSensor.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/equipment/2004/waterVaporSensor.xsd</li>
+            </ul>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Combined all equipment definitions into one file</li>
+                <li>Made all sensor types inherit from geo:SensorWithCodeType and geo:SensorType</li>
+                <li>Replaced the use of enumerations with GML code lists (the original enumeration values are still present)</li>
+                <li>Changed type of single date elements to gml:TimePosititionType</li>
+                <li>Changed date range elements references to gml:validTime</li>
+                <li>Changed types of numerical quantities from string to decimal</li>
+                <li>Added change tracking elements to all equipment types</li>
+                <li>Adopted GML conventions of global element definitions and property references</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <!-- restriction of geo:Instrument to require the type field.  -->
+    <complexType name="SensorWithCodeType">
+        <complexContent>
+            <restriction base="geo:SensorType">
+                <sequence>
+                    <sequence>
+                        <group ref="gml:StandardObjectProperties"/>
+                    </sequence>
+                    <sequence>
+                        <element name="type" type="gml:CodeType"/>
+                    </sequence>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!-- used by Temperature, Humidity, Water Vapor, and Pressure Sensors  -->
+    <complexType name="BaseSensorEquipmentType">
+        <complexContent>
+            <extension base="geo:SensorWithCodeType">
+                <sequence>
+                    <group ref="geo:RemarksGroup"/>
+                    <element name="manufacturer" type="string"/>
+                    <element name="serialNumber" type="string"/>
+                    <element name="heightDiffToAntenna" type="double"/>
+                    <element name="calibrationDate" type="gml:TimePositionType"/>
+                    <element ref="gml:validTime"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- used by gnss Antenna -->
+    <simpleType name="antennaReferencePointType">
+        <restriction base="string">
+            <enumeration value="BPA"/>
+            <enumeration value="BCR"/>
+            <enumeration value="BGP"/>
+            <enumeration value="TPA"/>
+            <enumeration value="TCR"/>
+            <enumeration value="TGR"/>
+        </restriction>
+    </simpleType>
+    <!-- TODO: use gco code list values -->
+    <element name="antennaReferencePoint" type="gml:CodeType"/>
+    <!-- used by gnss Receiver -->
+    <simpleType name="satelliteSystemTypeOfType">
+        <restriction base="string">
+            <enumeration value="n/a"/>
+            <enumeration value="GPS"/>
+            <enumeration value="GLONASS"/>
+            <enumeration value="GPS+GLONASS"/>
+        </restriction>
+    </simpleType>
+    <!-- used by collocation information-->
+    <simpleType name="instrumentationTypeOfType">
+        <restriction base="string">
+            <enumeration value="Absolute Gravimeter"/>
+            <enumeration value="Circumzenithal VUGTK"/>
+            <enumeration value="DORIS"/>
+            <enumeration value="DORIS/SLR"/>
+            <enumeration value="DORIS/SLR/VLBI"/>
+            <enumeration value="Earth Tide Gravimeter"/>
+            <enumeration value="GLONASS receiver"/>
+            <enumeration value="WLRS"/>
+            <enumeration value="PRARE"/>
+            <enumeration value="DORIS/SLR/VLBI"/>
+            <enumeration value="Earth Tide Gravimeter"/>
+            <enumeration value="GLONASS receiver"/>
+            <enumeration value="WLRS"/>
+            <enumeration value="PRARE"/>
+            <enumeration value="Radio Telescope"/>
+            <enumeration value="SATREF"/>
+            <enumeration value="Siesmometer"/>
+            <enumeration value="SLP"/>
+            <enumeration value="Satellite Laser Ranging"/>
+            <enumeration value="SLR/VLBI"/>
+            <enumeration value="Very Large Baseline Interferometry"/>
+            <enumeration value="Superconducting Gravimeter"/>
+            <enumeration value="Transportable Integrated Geodetic Observatory"/>
+            <enumeration value="Tidal Gravimeter"/>
+            <enumeration value="Very Broad Band Seismograph"/>
+            <enumeration value="Campaign Mode GPS"/>
+            <enumeration value="Continuously Operating GPS"/>
+            <enumeration value="Transit"/>
+            <enumeration value="Not Available/unknown"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <simpleType name="statusType">
+        <restriction base="string">
+            <enumeration value="n/a"/>
+            <enumeration value="ACTIVE"/>
+            <enumeration value="MOBILE"/>
+            <enumeration value="PERMANENT"/>
+            <enumeration value="REMOVED"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <!-- used by frequency standard -->
+    <simpleType name="standardTypeOfType">
+        <restriction base="string">
+            <enumeration value="none"/>
+            <enumeration value="H-MASER"/>
+            <enumeration value="CESIUM"/>
+            <enumeration value="QUARTZ"/>
+            <enumeration value="INTERNAL"/>
+            <enumeration value="RUBIDIUM"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <complexType name="GnssAntennaType">
+        <complexContent>
+            <extension base="geo:AbstractGNSSAntennaType">
+                <sequence>
+                    <!-- TODO: use gco code list values -->
+                    <element name="antennaReferencePoint" type="gml:CodeType"/>
+                    <element name="marker-arpUpEcc." type="double" nillable="true"/>
+                    <element name="marker-arpNorthEcc." type="double" nillable="true"/>
+                    <element name="marker-arpEastEcc." type="double" nillable="true"/>
+                    <element name="alignmentFromTrueNorth" type="double" nillable="true"/>
+                    <element name="antennaRadomeType" type="geo:igsRadomeModelCodeType"/>
+                    <element name="radomeSerialNumber" type="string"/>
+                    <element name="antennaCableType" type="string"/>
+                    <element name="antennaCableLength" type="double" nillable="true"/>
+                    <element name="dateInstalled" type="gml:TimePositionType"/>
+                    <element name="dateRemoved" type="gml:TimePositionType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="CollocationInformationType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <!-- TODO: use gco code list values -->
+                    <element name="instrumentationType" type="gml:CodeType"/>
+                    <element name="status" type="gml:CodeType"/>
+                    <element ref="gml:validTime"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="FrequencyStandardType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <!-- TODO: use gco -->
+                    <element name="standardType" type="gml:CodeType"/>
+                    <element minOccurs="0" name="inputFrequency" type="double"/>
+                    <element ref="gml:validTime"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="HumiditySensorType">
+        <complexContent>
+            <extension base="geo:BaseSensorEquipmentType">
+                <sequence>
+                    <element name="dataSamplingInterval" type="double"/>
+                    <element name="accuracy-percentRelativeHumidity" type="double"/>
+                    <element name="aspiration" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="OtherInstrumentationType">
+        <complexContent>
+            <extension base="geo:InstrumentType">
+                <sequence>
+                    <element name="instrumentation" type="string"/>
+                    <element ref="gml:validTime"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="PressureSensorType">
+        <complexContent>
+            <extension base="geo:BaseSensorEquipmentType">
+                <sequence>
+                    <element name="dataSamplingInterval" type="double"/>
+                    <element name="accuracy-hPa" type="double"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="GnssReceiverType">
+        <complexContent>
+            <extension base="geo:AbstractGNSSReceiverType">
+                <sequence>
+                    <!-- TODO: use gco -->
+                    <element maxOccurs="unbounded" name="satelliteSystem" type="gml:CodeType"/>
+                    <element name="firmwareVersion" type="string"/>
+                    <element name="elevationCutoffSetting" type="double" nillable="true"/>
+                    <element name="dateInstalled" type="gml:TimePositionType"/>
+                    <element name="dateRemoved" type="gml:TimePositionType"/>
+                    <element name="temperatureStabilization" type="double" nillable="true"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="SurveyedLocalTieType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="tiedMarkerName" type="string"/>
+                    <element name="tiedMarkerUsage" type="string"/>
+                    <element name="tiedMarkerCDPNumber" type="string"/>
+                    <element name="tiedMarkerDOMESNumber" type="string"/>
+                    <element name="differentialComponentsGNSSMarkerToTiedMonumentITRS" nillable="true">
+                        <complexType>
+                            <sequence>
+                                <element name="dx" type="double"/>
+                                <element name="dy" type="double"/>
+                                <element name="dz" type="double"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    <element name="localSiteTiesAccuracy" type="double" nillable="true"/>
+                    <element name="surveyMethod" type="string"/>
+                    <element name="dateMeasured" type="gml:TimePositionType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- Alternative to surveyedLocalTieType -->
+    <complexType name="TieMeasurementType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="Tie" type="geo:MeasurementLineType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="tiePairQuality" type="geo:MeasurementLineCovarianceType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="TemperatureSensorType">
+        <complexContent>
+            <extension base="geo:BaseSensorEquipmentType">
+                <sequence>
+                    <element name="dataSamplingInterval" type="double"/>
+                    <element name="accuracy-degreesCelcius" type="double"/>
+                    <element name="aspiration" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="WaterVaporSensorType">
+        <complexContent>
+            <extension base="geo:BaseSensorEquipmentType">
+                <sequence>
+                    <element name="distanceToAntenna" type="double"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  Global elements for each equipment type -->
+    <element name="GnssRadome" substitutionGroup="geo:Instrument" type="geo:GnssRadomeType"/>
+    <element name="GnssReceiver" substitutionGroup="geo:Instrument" type="geo:GnssReceiverType"/>
+    <element name="GnssAntenna" substitutionGroup="geo:Instrument" type="geo:GnssAntennaType"/>
+    <element name="HumiditySensor" substitutionGroup="geo:Sensor" type="geo:HumiditySensorType"/>
+    <element name="PressureSensor" substitutionGroup="geo:Sensor" type="geo:PressureSensorType"/>
+    <element name="TemperatureSensor" substitutionGroup="geo:Sensor" type="geo:TemperatureSensorType"/>
+    <element name="WaterVaporSensor" substitutionGroup="geo:Sensor" type="geo:WaterVaporSensorType"/>
+    <element name="OtherInstrumentation" substitutionGroup="geo:Instrument" type="geo:OtherInstrumentationType"/>
+    <element name="TieMeasurement" substitutionGroup="geo:AbstractMeasurement" type="geo:TieMeasurementType"/>
+    <element name="SurveyedLocalTie" substitutionGroup="gml:AbstractFeature" type="geo:SurveyedLocalTieType"/>
+    <element name="FrequencyStandard" substitutionGroup="gml:AbstractGML" type="geo:FrequencyStandardType"/>
+    <element name="CollocationInformation" substitutionGroup="gml:AbstractGML" type="geo:CollocationInformationType"/>
+    <!--  Property types for each equipment type -->
+    <complexType name="gnssReceiverPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:GnssReceiver"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="gnssAntennaPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:GnssAntenna"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="humiditySensorPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:HumiditySensor"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="pressureSensorPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:PressureSensor"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="temperatureSensorPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:TemperatureSensor"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="waterVaporSensorPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:WaterVaporSensor"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="otherInstrumentationPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:OtherInstrumentation"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="gnssRadomePropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:GnssRadome"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="surveyedLocalTiePropertyType">
+        <sequence>
+            <choice minOccurs="0">
+                <element ref="geo:SurveyedLocalTie"/>
+                <element ref="geo:TieMeasurement"/>
+            </choice>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="frequencyStandardPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:FrequencyStandard"/>
+                <group ref="geo:RemarksGroup"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="collocationInformationPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:CollocationInformation"/>
+
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+</schema>

--- a/schemas/geodesyml/0.6/equipment.xsd
+++ b/schemas/geodesyml/0.6/equipment.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <include schemaLocation="geodeticEquipment.xsd"/>
     <include schemaLocation="fieldMeasurement.xsd"/>

--- a/schemas/geodesyml/0.6/fieldMeasurement.xsd
+++ b/schemas/geodesyml/0.6/fieldMeasurement.xsd
@@ -1,0 +1,170 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <include schemaLocation="observationSystem.xsd"/>
+    <include schemaLocation="project.xsd"/>
+    <!--  -->
+    <complexType name="SetupPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Setup"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Setup" substitutionGroup="geo:DynamicFeature" type="geo:SetupType"/>
+    <!--  -->
+    <complexType name="SetupType">
+        <complexContent>
+            <extension base="geo:DynamicFeatureType">
+                <sequence>
+                    <element minOccurs="0" name="atSite" type="geo:SitePropertyType"/>
+                    <element minOccurs="0" name="history">
+                        <complexType>
+                            <sequence>
+                                <element maxOccurs="unbounded" ref="geo:SetupInstance"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="SetupInstance" substitutionGroup="geo:AbstractTimeSlice" type="geo:SetupInstanceType"/>
+    <!--  -->
+    <complexType name="SetupInstanceType">
+        <annotation>
+            <documentation>A geo:AbstractTimeSliceType extension to contain the value object for a setup instance. The date of setup is defined as the gml:validTime element inherited from geo:AbstractTimeSliceType.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractTimeSliceType">
+                <sequence>
+                    <element minOccurs="0" name="fromProject" type="geo:ProjectPropertyType"/>
+                    <element minOccurs="0" name="setupHeight" type="geo:ValueType"/>
+                    <element minOccurs="0" name="observedBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="usesInstrument" type="geo:InstrumentPropertyType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="usesSensor" type="geo:SensorPropertyType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="SensorPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Sensor"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Sensor" substitutionGroup="gml:AbstractGML" type="geo:SensorType"/>
+    <!--  -->
+    <complexType name="SensorType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element minOccurs="0" name="type" type="gml:CodeType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="ObservationQualityPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractObservationQuality"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractObservationQuality" substitutionGroup="gml:AbstractFeature" type="geo:AbstractObservationQualityType">
+        <annotation>
+            <documentation>Abstract class to contain observation-specific environment quality. For example, GNSS node quality.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="AbstractObservationQualityType">
+        <complexContent>
+            <extension base="geo:DynamicFeatureType">
+                <sequence>
+                    <element name="atSite" type="geo:SitePropertyType"/>
+                    <element minOccurs="0" name="source" type="geo:ObservationQualitySourcePropertyType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="GNSSObservationQuality" substitutionGroup="geo:AbstractObservationQuality" type="geo:GNSSObservationQualityType">
+        <annotation>
+            <documentation>Abstract class to contain observation-specific environment quality. For example, GNSS node quality.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="GNSSObservationQualityType">
+        <complexContent>
+            <extension base="geo:AbstractObservationQualityType">
+                <sequence>
+                    <element minOccurs="0" name="history">
+                        <complexType>
+                            <sequence>
+                                <element maxOccurs="unbounded" ref="geo:GNSSObservationQualityInstance"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="GNSSObservationQualityInstance" substitutionGroup="geo:AbstractTimeSlice" type="geo:GNSSObservationQualityInstanceType"/>
+    <!--  -->
+    <complexType name="GNSSObservationQualityInstanceType">
+        <annotation>
+            <documentation>A set of Site quality metrics computed daily to evaluate a Site's fitness or level of suitability in downstream GNSS analysis.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractTimeSliceType">
+                <sequence>
+                    <element name="FirstObservedEpoch" type="gml:TimePositionType">
+                        <annotation>
+                            <documentation>The function of this element and the next may overlap with the ValidTime TimePeriod element inherited by this complexType from AbstractTimeSliceType.</documentation>
+                        </annotation>
+                    </element>
+                    <element name="LastObservedEpoch" type="gml:TimePositionType"/>
+                    <element name="PossibleEpochs" type="integer"/>
+                    <element name="ObservedEpochs" type="integer"/>
+                    <element name="EpochPercent" type="double"/>
+                    <element name="averageMultipathL1" type="geo:ValueType"/>
+                    <element name="AverageMutlipathL2" type="geo:ValueType"/>
+                    <element name="PossibleObservations" type="integer"/>
+                    <element name="CompleteObservations" type="integer"/>
+                    <element name="DeletedObservations" type="integer"/>
+                    <element name="MaskedObservations" type="integer"/>
+                    <element name="ObservationRate" type="geo:ValueType"/>
+                    <element name="ObservationSlipRatio" type="geo:ValueType"/>
+                    <element name="ObservationsMissingL1" type="integer"/>
+                    <element name="ObservationsMissingL2" type="integer"/>
+                    <element name="ObservationsMissingP1orC1" type="integer"/>
+                    <element name="ObservatinosMissingP2orC2" type="integer"/>
+                    <element name="ReceiverTrackingCapability" type="integer"/>
+                    <element name="TotalSatellites" type="integer"/>
+                    <element name="MeanS1" type="geo:ValueType"/>
+                    <element name="Means1" type="geo:ValueType"/>
+                    <element minOccurs="0" name="source" type="geo:ObservationQualitySourcePropertyType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/fieldMeasurement.xsd
+++ b/schemas/geodesyml/0.6/fieldMeasurement.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6"  xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/geodesyML.xsd
+++ b/schemas/geodesyml/0.6/geodesyML.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <!--  -->
+    <include schemaLocation="commonTypes.xsd"/>
+    <include schemaLocation="quality.xsd"/>
+    <include schemaLocation="observationSystem.xsd"/>
+    <include schemaLocation="lineage.xsd"/>
+    <include schemaLocation="referenceFrame.xsd"/>
+    <include schemaLocation="document.xsd"/>
+    <include schemaLocation="fieldMeasurement.xsd"/>
+    <include schemaLocation="measurement.xsd"/>
+    <include schemaLocation="project.xsd"/>
+    <!--  -->
+    <include schemaLocation="siteLog.xsd"/>
+    <!--  -->
+    <complexType name="GeodesyMLPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:GeodesyML"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="GeodesyML" substitutionGroup="gml:AbstractFeature" type="geo:GeodesyMLType"/>
+    <!--  -->
+    <complexType name="GeodesyMLType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element minOccurs="0" ref="gml:validTime"/>
+                    <choice maxOccurs="unbounded">
+                        <element ref="geo:Node"/>
+                        <element ref="geo:AbstractPosition"/>
+                        <element ref="geo:PositionPairCovariance"/>
+                        <element ref="geo:Site"/>
+                        <element ref="geo:siteVisit"/>
+                        <element ref="geo:Monument"/>
+                        <element ref="geo:SupplementaryMark"/>
+                        <element ref="geo:AbstractMeasurement"/>
+                        <element ref="geo:Instrument"/>
+                        <element ref="geo:Sensor"/>
+                        <element ref="geo:AbstractPositionSource"/>
+                        <element ref="geo:AbstractPositionEstimator"/>
+                        <element ref="geo:AbstractMeasurementSource"/>
+                        <element ref="geo:AbstractMeasurementOperation"/>
+                        <element ref="geo:AbstractDefinitionSource"/>
+                        <element ref="geo:AbstractDefinitionOperation"/>
+                        <element ref="geo:AbstractSiteLog"/>
+                        <element ref="geo:Project"/>
+                        <element ref="geo:Document"/>
+                        <element ref="geo:Setup"/>
+                        <element ref="geo:TerrestrialReferenceFrame"/>
+                        <element ref="geo:DynamicTransformation"/>
+                        <element ref="gml:AbstractCRS"/>
+                    </choice>
+                </sequence>
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+</schema>

--- a/schemas/geodesyml/0.6/geodesyML.xsd
+++ b/schemas/geodesyml/0.6/geodesyML.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/geodeticEquipment.xsd
+++ b/schemas/geodesyml/0.6/geodeticEquipment.xsd
@@ -1,0 +1,343 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gco/gco.xsd"/>
+    <include schemaLocation="fieldMeasurement.xsd"/>
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011</p>
+            <ul>
+                <li>http://sopac.ucsd.edu/ns/geodesy/base/geodeticEquipment/gnssAntenna/2003/10/gnssAntenna.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/base/geodeticEquipment/gnssReceiver/2003/10/gnssReceiver.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/base/geodeticEquipment/gnssRadome/2003/10/gnssRadome.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/base/geodeticEquipment/2003/10/geodeticEquipment.xsd</li>
+            </ul>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Combined all geodetic equipment definitions into one file</li>
+                <li>Changed baseGeodeticEquipmentType to inherit from geo:InstrumentType</li>
+                <li>Defined radome, antenna, and receiver configuration types</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <complexType name="geodeticEquipmentItemPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:geodeticEquipmentItem"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <element abstract="false" name="geodeticEquipmentItem" type="geo:baseGeodeticEquipmentType">
+        <annotation>
+            <documentation>
+         Provides a base non-instantiable element type whose
+         structure is a derived complex type.  This element
+         can then be referenced as a substitutionGroup for
+         equipment cataloges and such.
+            </documentation>
+        </annotation>
+    </element>
+    <complexType abstract="true" name="baseGeodeticEquipmentType">
+        <annotation>
+            <documentation>
+         Base Geodetic Equipment class.  Serves as a platform
+         for the construction of other, more specific, types
+         of equipment related to the field of geodesy.  More
+         specifically, this class is designed for equipment
+         that can be uniquely-identified.  In other words,
+         actual physical objects used in geodetic practices.
+
+         GeodesyML 0.2 change: Extend geo:InstrumentType and removed attr  final="restriction"
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:InstrumentType">
+                <sequence>
+                    <!-- -->
+                    <!-- Manufacturer Name -->
+                    <!-- -->
+                    <element minOccurs="0" name="manufacturerName" type="string"/>
+                    <!-- -->
+                    <!-- Manufacturer Model -->
+                    <!-- -->
+                    <element minOccurs="0" name="manufacturerModel" type="string"/>
+                    <!-- -->
+                    <!-- Manufacturer Part Number -->
+                    <!-- -->
+                    <element minOccurs="0" name="manufacturerPartNumber" type="string"/>
+                    <!-- -->
+                    <!-- Manufacturer Description -->
+                    <!-- -->
+                    <element minOccurs="0" name="manufacturerDescription" type="string"/>
+                    <!-- -->
+                    <!-- Manufacturer Serial Number -->
+                    <!-- -->
+                    <element name="manufacturerSerialNumber" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <!--  -->
+    <!--<element name="gnssAntenna" type="geo:gnssAbstractAntennaType"/>-->
+    <complexType abstract="true" name="AbstractGNSSAntennaType">
+        <annotation>
+            <documentation xml:lang="en">
+        Instantiable, non-substituble, global complex type
+        representing a GNSS Antenna uniquely-identified
+        by a serial number and IGS model code.
+
+        GeodesyML 0.2: removed block="#all" attribute.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:baseGeodeticEquipmentType">
+                <sequence>
+                    <element minOccurs="0" name="igsModelCode" type="geo:igsAntennaModelCodeType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType abstract="false" block="#all" name="gnssAntennaConfigType">
+        <annotation>
+            <documentation xml:lang="en">
+        Instantiable, non-substituble, global complex type
+        representing the settings (transient properties)
+        of a gnss antenna.
+            </documentation>
+        </annotation>
+        <choice maxOccurs="2" minOccurs="0">
+            <element minOccurs="0" name="antennaCableLengthMeters">
+                <annotation>
+                    <documentation>
+            Refers to the length (in meters) of the cable
+            used to connect the antenna to other gnss equipment
+            (typically a gnss receiver or set of receivers).
+                    </documentation>
+                </annotation>
+                <simpleType>
+                    <restriction base="decimal">
+                        <totalDigits value="6"/>
+                        <fractionDigits value="3"/>
+                    </restriction>
+                </simpleType>
+            </element>
+            <element minOccurs="0" name="antennaCableType" type="string">
+                <annotation>
+                    <documentation>
+            Refers to the type of cable
+            used to connect the antenna to other gnss equipment
+            (typically a gnss receiver or set of receivers).
+                    </documentation>
+                </annotation>
+            </element>
+        </choice>
+    </complexType>
+    <complexType abstract="false" block="#all" name="gnssAntennaHeightMeasurementType">
+        <annotation>
+            <documentation xml:lang="en">
+        Instantiable, non-substituble, global complex type
+        representing the measurement of a distance between
+        a specified location on a gnss antenna and another
+        location of choice.
+            </documentation>
+        </annotation>
+        <choice maxOccurs="5">
+            <element default="vertical" minOccurs="0" name="type" type="gml:CodeWithAuthorityType"/>
+            <element name="value">
+                <annotation>
+                    <documentation>
+            Refers to the distance (+|-) between the geodetic
+            reference point of the associated monument, and a
+            chosen reference point on the antenna.
+                    </documentation>
+                </annotation>
+                <simpleType>
+                    <restriction base="decimal">
+                        <totalDigits value="6"/>
+                        <fractionDigits value="4"/>
+                    </restriction>
+                </simpleType>
+            </element>
+            <element minOccurs="0" ref="gml:unitOfMeasure"/>
+            <element default="BPA" minOccurs="0" name="referencePoint" type="gml:CodeWithAuthorityType"/>
+            <element minOccurs="0" name="dateAndTimeUTC" type="gml:TimePositionType"/>
+        </choice>
+    </complexType>
+    <complexType final="#all" name="igsAntennaModelCodeType">
+        <annotation>
+            <documentation xml:lang="en">
+        Non-instantiable, non-substituable, non-extendable or
+        restrictable global simple type representing a valid
+        IGS antenna model code.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gco:CodeListValue_Type"/>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <complexType block="#all" name="GnssRadomeType">
+        <annotation>
+            <documentation xml:lang="en">
+        Instantiable, non-substituble, global complex type
+        representing a GNSS Radome uniquely-identified
+        by a serial number and IGS model code.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:baseGeodeticEquipmentType">
+                <sequence>
+                    <element minOccurs="0" name="igsModelCode" type="geo:igsRadomeModelCodeType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType abstract="false" block="#all" name="gnssRadomeConfigType">
+        <annotation>
+            <documentation xml:lang="en">
+        Instantiable, non-substituble, global complex type
+        representing the settings (transient properties)
+        of a gnss radome.
+            </documentation>
+        </annotation>
+        <choice minOccurs="0">
+            <element minOccurs="0" name="radomeFastenerType" type="string">
+                <annotation>
+                    <documentation>
+            Refers to the type of fasteners used to secure a radome
+            in place.  This is pretty much a bogus data field
+            intended for future compatibility purposes.
+          </documentation>
+                </annotation>
+            </element>
+        </choice>
+    </complexType>
+    <complexType final="#all" name="igsRadomeModelCodeType">
+        <annotation>
+            <documentation xml:lang="en">
+        Non-instantiable, non-substituable, non-extendable or
+        restrictable global simple type representing a valid
+        IGS radome model code.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:CodeWithAuthorityType"/>
+        </complexContent>
+    </complexType>
+    <element name="igsRadomeModelCode" type="geo:igsRadomeModelCodeType"/>
+    <!-- -->
+    <!--<element name="gnssReceiver" type="geo:AbstractGnssReceiverType"/>-->
+    <complexType abstract="true" name="AbstractGNSSReceiverType">
+        <annotation>
+            <documentation xml:lang="en">
+                Instantiable, non-substituble, global complex type
+                representing a GNSS Receiver uniquely-identified
+                by a serial number and IGS model code.
+
+                GeodesyML 0.2 changes: removed  block="#all"
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:baseGeodeticEquipmentType">
+                <sequence>
+                    <element minOccurs="0" name="igsModelCode" type="geo:igsReceiverModelCodeType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType abstract="false" block="#all" name="gnssReceiverConfigType">
+        <annotation>
+            <documentation xml:lang="en">
+                Instantiable, non-substituble, global complex type
+                representing the settings (transient properties)
+                of a gnss receiver.
+            </documentation>
+        </annotation>
+        <choice maxOccurs="6" minOccurs="0">
+            <element minOccurs="0" name="satelliteSystem" type="gml:CodeListType">
+                <annotation>
+                    <documentation>
+                        Refers to a satellite
+                        constellation being observed by a gnss receiver.
+                    </documentation>
+                </annotation>
+            </element>
+            <element minOccurs="0" name="firmwareVersion" type="string">
+                <annotation>
+                    <documentation>
+                        Refers to the manufacturer-
+                        designated version of the firmware installed
+                        on a gnss receiver.
+                    </documentation>
+                </annotation>
+            </element>
+            <element minOccurs="0" name="elevationCutoff" type="string">
+                <annotation>
+                    <documentation>
+                        Refers to the elevation mask (or cutoff)
+                        used on a gnss receiver.
+                    </documentation>
+                </annotation>
+            </element>
+            <element minOccurs="0" name="temperatureStabilization" type="string">
+                <annotation>
+                    <documentation>
+                        Refers to the temperature stabilization
+                        on a gnss receiver.
+                    </documentation>
+                </annotation>
+            </element>
+            <element minOccurs="0" name="sampleIntervalInSeconds">
+                <annotation>
+                    <documentation>
+                        Refers to the sampling interval with which
+                        observations are made with respect to the observed
+                        constellation(s) of satellite(s).
+                    </documentation>
+                </annotation>
+                <simpleType>
+                    <restriction base="decimal">
+                        <totalDigits value="4"/>
+                        <fractionDigits value="1"/>
+                    </restriction>
+                </simpleType>
+            </element>
+            <element minOccurs="0" name="nativeBaudRateInBPS">
+                <annotation>
+                    <documentation>
+                        Refers to the sampling interval with which
+                        observations are made with respect to the observed
+                        constellation(s) of satellite(s).
+                    </documentation>
+                </annotation>
+                <simpleType>
+                    <restriction base="decimal">
+                        <totalDigits value="6"/>
+                        <fractionDigits value="0"/>
+                    </restriction>
+                </simpleType>
+            </element>
+        </choice>
+    </complexType>
+    <complexType final="#all" name="igsReceiverModelCodeType">
+        <annotation>
+            <documentation xml:lang="en">
+                Non-instantiable, non-substituable, non-extendable or
+                restrictable global simple type representing a valid
+                IGS receiver model code.  With a codeList attribute
+                to set the allowed types.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gco:CodeListValue_Type"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/geodeticEquipment.xsd
+++ b/schemas/geodesyml/0.6/geodeticEquipment.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gco/gco.xsd"/>
     <include schemaLocation="fieldMeasurement.xsd"/>

--- a/schemas/geodesyml/0.6/geodeticMonument.xsd
+++ b/schemas/geodesyml/0.6/geodeticMonument.xsd
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="observationSystem.xsd"/>
+    <simpleType name="geodeticMonumentTypeOfType">
+        <restriction base="string">
+            <enumeration value="pillar"/>
+            <enumeration value="brass plate"/>
+            <enumeration value="steel mast"/>
+            <enumeration value="shallow rod / braced antenna mount"/>
+            <enumeration value="removeable tripod / concrete pad"/>
+            <enumeration value="Wyatt/Agnew drilled-braced"/>
+            <enumeration value="Wyatt/Agnew driven braced"/>
+            <enumeration value="rock-pin/metal-tripod"/>
+            <enumeration value="rock-pin"/>
+            <enumeration value="glued-rod"/>
+            <enumeration value="wall"/>
+        </restriction>
+    </simpleType>
+    <simpleType name="geodeticMonumentFoundationTypeOfType">
+        <restriction base="string">
+            <enumeration value="roof"/>
+            <enumeration value="concrete block"/>
+            <enumeration value="steel rods"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <element name="geodeticMonument" substitutionGroup="gml:AbstractFeature" type="geo:baseGeodeticMonumentType"/>
+    <!--  -->
+    <complexType name="geodeticMonumentPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:geodeticMonument"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType abstract="false" block="#all" name="baseGeodeticMonumentType">
+        <annotation>
+            <documentation>
+         Base geodetic monument class.  Can be extended..
+         Cannot be substituted and is instantiable.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <!-- Monument Type -->
+                    <!-- TODO: use gco -->
+                    <element minOccurs="0" name="type" type="gml:CodeType"/>
+                    <!-- Common Name -->
+                    <element minOccurs="0" name="commonName" type="string"/>
+                    <!-- Common Character Identifier -->
+                    <element name="characterIdentifier">
+                        <simpleType>
+                            <restriction base="string">
+                                <length value="4"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <!-- Inscription -->
+                    <element minOccurs="0" name="inscription" type="string"/>
+                    <!-- IERS Domes Number -->
+                    <element minOccurs="0" name="iersDomesNumber" type="string"/>
+                    <!-- CDP Number -->
+                    <element minOccurs="0" name="cdpNumber" type="string"/>
+                    <!-- NGS PID -->
+                    <element minOccurs="0" name="ngsPID">
+                        <simpleType>
+                            <restriction base="string">
+                                <length value="6"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <!-- Verbal Location -->
+                    <element minOccurs="0" name="verbalLocation" type="string"/>
+                    <!-- Geodetic Position -->
+                    <element name="geodeticPosition" type="geo:PositionPropertyType"/>
+                    <!--
+                    <element name="geodeticPosition">
+                        <complexType>
+                            <sequence>
+                                <element name="longitude">
+                                    <simpleType>
+                                        <restriction base="decimal">
+                                            <totalDigits value="11"/>
+                                            <fractionDigits value="8"/>
+                                        </restriction>
+                                    </simpleType>
+                                </element>
+                                <element name="latitude">
+                                    <simpleType>
+                                        <restriction base="decimal">
+                                            <totalDigits value="10"/>
+                                            <fractionDigits value="8"/>
+                                        </restriction>
+                                    </simpleType>
+                                </element>
+                                <element name="elevation">
+                                    <simpleType>
+                                        <restriction base="decimal">
+                                            <totalDigits value="9"/>
+                                            <fractionDigits value="4"/>
+                                        </restriction>
+                                    </simpleType>
+                                </element>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    -->
+                    <!-- City (nearest) -->
+                    <element minOccurs="0" name="nearestCity" type="string"/>
+                    <!-- State, Province, Region, Territory -->
+                    <element minOccurs="0" name="territory" type="string"/>
+                    <!-- Country -->
+                    <element name="country" type="string"/>
+                    <!-- Height (of the monument, in meters) -->
+                    <element minOccurs="0" name="monumentHeight">
+                        <simpleType>
+                            <restriction base="decimal">
+                                <totalDigits value="6"/>
+                                <fractionDigits value="4"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <!-- Foundation -->
+                    <!-- TODO: use gco -->
+                    <element minOccurs="0" name="monumentFoundation" type="gml:CodeType"/>
+                    <!-- Foundation Depth -->
+                    <element minOccurs="0" name="monumentFoundationDepth">
+                        <simpleType>
+                            <restriction base="decimal">
+                                <totalDigits value="6"/>
+                                <fractionDigits value="4"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <!-- Geologic Characteristics -->
+                    <element minOccurs="0" name="geologicCharacteristics" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/geodeticMonument.xsd
+++ b/schemas/geodesyml/0.6/geodeticMonument.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <include schemaLocation="observationSystem.xsd"/>
     <simpleType name="geodeticMonumentTypeOfType">

--- a/schemas/geodesyml/0.6/lineage.xsd
+++ b/schemas/geodesyml/0.6/lineage.xsd
@@ -1,0 +1,614 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.opengis.net/om/2.0" schemaLocation="http://schemas.opengis.net/om/2.0/observation.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <!--  -->
+    <include schemaLocation="commonTypes.xsd"/>
+    <include schemaLocation="quality.xsd"/>
+    <include schemaLocation="observationSystem.xsd"/>
+    <include schemaLocation="measurement.xsd"/>
+    <!--  -->
+    <complexType name="AbstractSourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractSource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractSource" substitutionGroup="gml:AbstractFeature" type="geo:AbstractSourceType"/>
+    <!--  -->
+    <complexType abstract="true" name="AbstractSourceType">
+        <annotation>
+            <documentation>Encapsulates operands and results related to the event of running an operation. It is intended that this complex type is extended to include a reference to the particular operation type to be recorded.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element ref="gml:validTime">
+                        <annotation>
+                            <documentation>The valid time range or instant for this encapsulation.</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" name="runDate" type="gml:TimePositionType">
+                        <annotation>
+                            <documentation>Date and time this operation was run.</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" name="runBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element minOccurs="0" name="operands">
+                        <complexType>
+                            <sequence maxOccurs="unbounded">
+                                <element ref="geo:AbstractOperand"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    <element minOccurs="0" name="results">
+                        <complexType>
+                            <sequence maxOccurs="unbounded">
+                                <element ref="geo:AbstractResult"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="AbstractPositionSourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractPositionSource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractPositionSource" substitutionGroup="geo:AbstractSource" type="geo:AbstractPositionSourceType">
+        <annotation>
+            <documentation>Version 0.2.2: Define an abstract type to encapsulate the inputs and outputs of an "instance" of a coordinate operation. This instance is recorded to maintain the traceable lineage of a Position value.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="AbstractPositionSourceType">
+        <annotation>
+            <documentation>Encapsulates</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSourceType">
+                <sequence>
+                    <element name="operation" type="gml:CoordinateOperationPropertyType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element abstract="true" name="AbstractPositionEstimator" substitutionGroup="gml:AbstractCoordinateOperation" type="geo:AbstractPositionEstimatorType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of estimators. Extends AbstractCoordinateOperation. gml:targetCRS and gml:sourceCRS have been removed.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractPositionEstimatorType">
+        <complexContent>
+            <restriction base="gml:AbstractCoordinateOperationType">
+                <sequence>
+                    <sequence>
+                        <element maxOccurs="unbounded" minOccurs="0" ref="gml:metaDataProperty"/>
+                        <element minOccurs="0" ref="gml:description"/>
+                        <element minOccurs="0" ref="gml:descriptionReference"/>
+                        <element ref="gml:identifier"/>
+                        <element maxOccurs="unbounded" minOccurs="0" ref="gml:name"/>
+                    </sequence>
+                    <sequence>
+                        <element minOccurs="0" ref="gml:remarks"/>
+                    </sequence>
+                    <sequence>
+                        <element minOccurs="0" ref="gml:domainOfValidity"/>
+                        <element maxOccurs="unbounded" ref="gml:scope"/>
+                        <element minOccurs="0" ref="gml:operationVersion"/>
+                        <element maxOccurs="unbounded" minOccurs="0" ref="gml:coordinateOperationAccuracy"/>
+                    </sequence>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="PositionSource" substitutionGroup="geo:AbstractPositionSource" type="geo:PositionSourceType"/>
+    <!--  -->
+    <complexType name="PositionSourceType">
+        <annotation>
+            <documentation>A position source encapsulates any position estimation operation with source and destination references to operands, resultant parameters and configuration options.
+                To encapsulate a geodetic adjustment, the least squares estimation operation would be the referenced along with operand positions and measurements.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractPositionSourceType">
+                <sequence>
+                    <element minOccurs="0" name="EstimationType" type="gml:CodeType">
+                        <annotation>
+                            <documentation>For clarity and identification purposes, some vendors may choose to denote the type of position estimation using a code supplied by a third party dictionary. A typical entry might be one of an enumeration of "Geodetic Adjustment", "National Adjustment" and "Campaign Adjustment" or could refer to a SINEX solution produced by Bernese "Daily Bernese SINEX" or "Weekly Bernese SINEX". This type is flexible enough to refer to both the business purpose for the estimation as well as infer the technique used in the estimation process.</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" name="version" type="string"/>
+                    <element minOccurs="0" name="epoch" type="gml:TimePositionType"/>
+                    <element minOccurs="0" ref="geo:Status"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="configureValue" type="geo:ValueType">
+                        <annotation>
+                            <documentation>In a geodetic adjustment a typical configureValue codeSpace would be the confidence interval for the t-test or f-test, or the computed degrees of freedom, number of measurements or positions, or estimator type.</documentation>
+                        </annotation>
+                    </element>
+                </sequence>
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+            <!--<attributeGroup ref="geo:SpatialReferenceGroup"/>-->
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="PositionEstimatorProcess" substitutionGroup="geo:AbstractPositionEstimator" type="geo:PositionEstimatorProcessType">
+        <annotation>
+            <documentation>Contains process steps that identify processes used for the generation of position parameters.
+                For geodetic adjustments this could involve a preprocessing step for generation of apriori coordinates, adjustment phases, outlier detection and removal and any other relevant procedures that impart a significant result on parameters.
+                For the generation of a SINEX file via GNSS processing software such as Bernese this type can be used to describe configuration steps.
+            </documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="PositionEstimatorProcessType">
+        <complexContent>
+            <extension base="geo:AbstractPositionEstimatorType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="processStep">
+                        <complexType>
+                            <sequence>
+                                <element name="description" type="string"/>
+                                <element minOccurs="0" name="processReference" type="gml:ReferenceType"/>
+                                <element maxOccurs="unbounded" minOccurs="0" name="processValue" type="geo:ValueType"/>
+                                <group ref="geo:RemarksGroup"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                </sequence>
+                <attribute name="dimension" type="geo:PositionDimensionEnumeration"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractOperand"/>
+    <!--  -->
+    <element abstract="true" name="AbstractResult"/>
+    <!--  -->
+    <element name="operand" substitutionGroup="geo:AbstractOperand" type="geo:AnyOperandType"/>
+    <!--  -->
+    <complexType name="AnyOperandType">
+        <sequence>
+            <element minOccurs="0" name="type" type="gml:CodeType"/>
+            <element minOccurs="0" name="value" type="anyType"/>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="result" substitutionGroup="geo:AbstractResult" type="geo:AnyResultType"/>
+    <!--  -->
+    <complexType name="AnyResultType">
+        <sequence>
+            <element minOccurs="0" name="type" type="gml:CodeType"/>
+            <element minOccurs="0" name="value" type="anyType"/>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="adjustmentPosition" substitutionGroup="geo:AbstractOperand" type="geo:adjustmentPositionType">
+        <annotation>
+            <documentation>Position for nodes within adjustment.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="adjustmentPositionType">
+        <annotation>
+            <documentation>A reference to the Position record and a description of parameters to constrain.</documentation>
+        </annotation>
+        <sequence>
+            <element name="usesPosition" type="geo:PositionPropertyType"/>
+            <element minOccurs="0" ref="geo:AbstractQuality">
+                <annotation>
+                    <documentation>This quality element acts as a datum constraint and is typically a VCV or PU constraint of this position to the datum of the estimation/adjustment. This element would be used in conjunction with the constraint attribute set to "Constrained".</documentation>
+                </annotation>
+            </element>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+        <attribute name="constraint" type="geo:NodeConstraintEnumeration"/>
+    </complexType>
+    <!--  -->
+    <element name="adjustmentMeasurement" substitutionGroup="geo:AbstractOperand" type="geo:adjustmentMeasurementType">
+        <annotation>
+            <documentation>Measurements within adjustment.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="adjustmentMeasurementType">
+        <sequence>
+            <element name="usesMeasurement" type="geo:AbstractMeasurementPropertyType"/>
+            <element maxOccurs="unbounded" minOccurs="0" name="aprioriScalar" type="geo:ValueType"/>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+        <attribute default="true" name="include" type="boolean"/>
+    </complexType>
+    <!--  -->
+    <element name="adjustmentValue" substitutionGroup="geo:AbstractResult" type="geo:ValueType">
+        <annotation>
+            <documentation>Used for returning information about the adjustment.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element name="adjustedPosition" substitutionGroup="geo:AbstractResult" type="geo:adjustedPositionType">
+        <annotation>
+            <documentation>Position returned from an adjustment. This element may be redundant since this link will be identified in a PositionType:source element.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="adjustedPositionType">
+        <sequence>
+            <element name="usesPosition" type="geo:PositionPropertyType"/>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="adjustedPositionQuality" substitutionGroup="geo:AbstractResult" type="geo:adjustedPositionQualityType">
+        <annotation>
+            <documentation>Covariances between adjusted positions determined as part of adjustment.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="adjustedPositionQualityType">
+        <sequence>
+            <element name="atPosition" type="gml:ReferenceType"/>
+            <element name="toPosition" type="gml:ReferenceType"/>
+            <element name="value" type="geo:ValueType"/>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="adjustedMeasurement" substitutionGroup="geo:AbstractResult" type="geo:adjustedMeasurementType">
+        <annotation>
+            <documentation>Additional values returned from an adjustment for measurement line.  For example may be residuals or statistics.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="adjustedMeasurementType">
+        <sequence>
+            <choice>
+                <element name="atLine" type="gml:ReferenceType"/>
+                <element name="atPoint" type="gml:ReferenceType"/>
+            </choice>
+            <element maxOccurs="unbounded" name="adjustmentValue" type="geo:ValueType"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="Transformation" substitutionGroup="geo:AbstractPositionSource" type="geo:TransformationType"/>
+    <!--  -->
+    <complexType name="TransformationType">
+        <annotation>
+            <documentation>A Transformation encapsulates the coordinate operation with source and destination references to operand and result data.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractPositionSourceType">
+                <sequence>
+                    <element minOccurs="0" name="version" type="string"/>
+                    <element minOccurs="0" name="epoch" type="gml:TimePositionType"/>
+                    <element name="status" type="gml:CodeType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+                <attributeGroup ref="gml:SRSReferenceGroup">
+                    <annotation>
+                        <documentation>The transformation source and destination CRS are required elements in the GML transformation coordinate operation. The ability to note the srsName and dimension of the results here is optional.</documentation>
+                    </annotation>
+                </attributeGroup>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="transformationPosition" substitutionGroup="geo:AbstractOperand" type="geo:transformationPositionType">
+        <annotation>
+            <documentation>The operand to a transformation on a position.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="transformationPositionType">
+        <sequence>
+            <element ref="geo:Position"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="transformationMeasurement" substitutionGroup="geo:AbstractOperand" type="geo:transformationMeasurementType">
+        <annotation>
+            <documentation>The operand to a transformation on a datum-defined measurement.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="transformationMeasurementType">
+        <sequence>
+            <element ref="geo:AbstractMeasurement"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="transformedPosition" substitutionGroup="geo:AbstractResult" type="geo:transformedPositionType">
+        <annotation>
+            <documentation>The result of a transformation on a position.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="transformedPositionType">
+        <sequence>
+            <element ref="geo:Position"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="transformedMeasurement" substitutionGroup="geo:AbstractResult" type="geo:transformedMeasurementType">
+        <annotation>
+            <documentation>The result of a transformation on a datum-defined measurement.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="transformedMeasurementType">
+        <sequence>
+            <element ref="geo:AbstractMeasurement"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <simpleType name="NodeConstraintEnumeration">
+        <restriction base="string">
+            <enumeration value="Free"/>
+            <enumeration value="Constrained"/>
+            <enumeration value="Constrained Vertical"/>
+            <enumeration value="Constrained Horizontal"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <simpleType name="PositionDimensionEnumeration">
+        <restriction base="string">
+            <enumeration value="1"/>
+            <enumeration value="2"/>
+            <enumeration value="3"/>
+            <enumeration value="4"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <complexType name="AbstractMeasurementSourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractMeasurementSource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractMeasurementSource" substitutionGroup="geo:AbstractSource" type="geo:AbstractMeasurementSourceType">
+        <annotation>
+            <documentation>Version 0.2.2: Encapsulates measurement operation and the operands/results that define the operation event.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="AbstractMeasurementSourceType">
+        <annotation>
+            <documentation>Encapsulates measurement operation and the operands/results that define the operation event.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSourceType">
+                <sequence>
+                    <element name="operation" type="geo:MeasurementOperationPropertyType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element abstract="true" name="AbstractMeasurementEstimator" substitutionGroup="geo:AbstractMeasurementOperation" type="geo:AbstractMeasurementEstimatorType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of estimators.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractMeasurementEstimatorType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractMeasurementOperation for the purpose of the definition of estimators. Extends AbstractMeasurementOperation.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractMeasurementOperationType">
+                <sequence/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractMeasurementOperation" substitutionGroup="gml:Definition" type="geo:AbstractMeasurementOperationType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of estimators.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractMeasurementOperationType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of estimators.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:IdentifiedObjectType">
+                <sequence>
+                    <element minOccurs="0" ref="geo:ReductionMethod"/>
+                    <element minOccurs="0" name="procedure" type="om:OM_ProcessPropertyType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="MeasurementOperationPropertyType">
+        <annotation>
+            <documentation>geo:MeasurementOperationPropertyType is a property type for association roles to a measurement operation, either referencing or containing the definition of that measurement operation.</documentation>
+        </annotation>
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractMeasurementOperation"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="GNSSBaselineReduction" substitutionGroup="geo:AbstractMeasurementSource" type="geo:GNSSBaselineReductionType"/>
+    <!--  -->
+    <complexType name="GNSSBaselineReductionType">
+        <annotation>
+            <documentation>A GNSS baseline reduction source encapsulates the baseline reductuin operation with operand and result properties and configuration values.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractMeasurementSourceType">
+                <sequence>
+                    <element minOccurs="0" name="version" type="string"/>
+                    <element name="status" type="gml:CodeType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="configureValue" type="geo:ValueType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="ReductionMethod" type="string"/>
+    <!--  -->
+    <complexType name="AbstractDefinitionSourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractDefinitionSource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractDefinitionSource" substitutionGroup="geo:AbstractSource" type="geo:AbstractDefinitionSourceType">
+        <annotation>
+            <documentation>Version 0.2.2: Define an abstract type to encapsulate the inputs and outputs of an "instance" of a coordinate operation. This instance is recorded to maintain the traceable lineage of a Position value.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="AbstractDefinitionSourceType">
+        <annotation>
+            <documentation>Encapsulates a reference to the operation definition used to produce resultant parameters that are gazetted in the gml:IdentifiedObject.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSourceType">
+                <sequence>
+                    <element ref="geo:AbstractDefinitionOperation"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element abstract="true" name="AbstractDefinitionEstimator" substitutionGroup="geo:AbstractDefinitionOperation" type="geo:AbstractDefinitionEstimatorType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of definition estimators. Usually defines a collocation or inversion.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractDefinitionEstimatorType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractMeasurementOperation for the purpose of the definition of estimators. Extends AbstractMeasurementOperation.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractDefinitionOperationType">
+                <sequence/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractDefinitionOperation" substitutionGroup="gml:Definition" type="geo:AbstractDefinitionOperationType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of definitons.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="AbstractDefinitionOperationType">
+        <annotation>
+            <documentation>Version 0.2.2: Mirrors the hierarchy of gml:AbstractCoordinateOperation for the purpose of the definition of estimators.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:IdentifiedObjectType">
+                <sequence/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="DefinitionOperationPropertyType">
+        <annotation>
+            <documentation>geo:DefinitionOperationPropertyType is a property type for association roles to a Definition operation, either referencing or containing the definition of that Definition operation.</documentation>
+        </annotation>
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractDefinitionOperation"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="ReferenceFrameSource" substitutionGroup="geo:AbstractDefinitionSource" type="geo:ReferenceFrameSourceType"/>
+    <!--  -->
+    <complexType name="ReferenceFrameSourceType">
+        <annotation>
+            <documentation>A Reference Frame Source encapsulates the inversion operation with position operands and a 14 parameter transform as a result.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractDefinitionSourceType">
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+            <!--<attributeGroup ref="geo:SpatialReferenceGroup"/>-->
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="InterpolatedValueSourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:InterpolatedValueSource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="InterpolatedValueSource" substitutionGroup="geo:AbstractSource" type="geo:InterpolatedValueSourceType">
+        <annotation>
+            <documentation>Version 0.2.2: Define an abstract type to encapsulate the operands, results and process of the operation event that produced an interpolated value.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="InterpolatedValueSourceType">
+        <annotation>
+            <documentation>Encapsulates the definition used to compute the interpolation, the gridded data operand and a result reference.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSourceType">
+                <sequence>
+                    <element name="definition" type="gml:DictionaryEntryType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="ObservationQualitySourcePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:ObservationQualitySource"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="ObservationQualitySource" substitutionGroup="geo:AbstractSource" type="geo:ObservationQualitySourceType">
+        <annotation>
+            <documentation>Version 0.2.2: Define an abstract type to encapsulate the operands, results and process of the operation event that produced observation quality meta-data.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType abstract="true" name="ObservationQualitySourceType">
+        <annotation>
+            <documentation>Encapsulates the definition used to compute the interpolation, the gridded data operand and a result reference.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSourceType">
+                <sequence>
+                    <element name="definition" type="gml:DictionaryEntryType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+</schema>

--- a/schemas/geodesyml/0.6/lineage.xsd
+++ b/schemas/geodesyml/0.6/lineage.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/localInterferences.xsd
+++ b/schemas/geodesyml/0.6/localInterferences.xsd
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011</p>
+            <ul>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004/baseLocalInterferencesLib.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004/localEvents.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004/localInterferences.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/localInterferences/2004/radioInterferences.xsd</li>
+            </ul>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Made all interference types extend gml:AbstractFeatureType</li>
+                <li>Changed date range elements to be references to gml:validTime</li>
+                <li>Adopted GML conventions of global elements and property references</li>
+                <li>Changed pluralised elements to singular forms</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <complexType name="basePossibleProblemSourceType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="possibleProblemSource" type="string"/>
+                    <element ref="gml:validTime"/>
+                    <element name="notes" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- pj, 01/27/2005: a "baseLocalInterferenceType" from this schema is used as a type in multiPath, but it is not here.  add it. -->
+    <simpleType final="#all" name="baseLocalInterferenceType">
+        <restriction base="string">
+            <enumeration value="TV"/>
+            <enumeration value="CELL PHONE"/>
+            <enumeration value="ANTENNA"/>
+            <enumeration value="RADAR"/>
+            <enumeration value="METAL ROOF"/>
+            <enumeration value="DOME"/>
+            <enumeration value="VLBI ANTENNA"/>
+            <enumeration value="TREES"/>
+            <enumeration value="BUILDINGS"/>
+        </restriction>
+    </simpleType>
+    <complexType name="multipathSourceType">
+        <complexContent>
+            <extension base="geo:basePossibleProblemSourceType"/>
+        </complexContent>
+    </complexType>
+    
+    <complexType name="signalObstructionType">
+        <complexContent>
+            <extension base="geo:basePossibleProblemSourceType"/>
+        </complexContent>
+    </complexType>
+    
+    <complexType name="radioInterferenceType">
+        <complexContent>
+            <extension base="geo:basePossibleProblemSourceType">
+                <sequence>
+                    <element name="observedDegradation" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    
+    <complexType name="localEpisodicEffectType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element ref="gml:validTime"/>
+                    <element name="event" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  Global elements -->
+    <element name="MultipathSource" substitutionGroup="gml:AbstractFeature" type="geo:multipathSourceType"/>
+    <element name="SignalObstruction" substitutionGroup="gml:AbstractFeature" type="geo:signalObstructionType"/>
+    <element name="RadioInterference" substitutionGroup="gml:AbstractFeature" type="geo:radioInterferenceType"/>
+    <element name="LocalEpisodicEffect" substitutionGroup="gml:AbstractFeature" type="geo:localEpisodicEffectType"/>
+    <!--  Property Types -->
+    <complexType name="multipathSourcePropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:MultipathSource"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="signalObstructionPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:SignalObstruction"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="radioInterferencePropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:RadioInterference"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="localEpisodicEffectPropertyType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element ref="geo:LocalEpisodicEffect"/>
+            </sequence>
+            <group ref="geo:ChangeTracking"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+</schema>

--- a/schemas/geodesyml/0.6/localInterferences.xsd
+++ b/schemas/geodesyml/0.6/localInterferences.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <include schemaLocation="commonTypes.xsd"/>
     <annotation>

--- a/schemas/geodesyml/0.6/measurement.xsd
+++ b/schemas/geodesyml/0.6/measurement.xsd
@@ -1,0 +1,473 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <include schemaLocation="quality.xsd"/>
+    <include schemaLocation="project.xsd"/>
+    <include schemaLocation="lineage.xsd"/>
+    <include schemaLocation="fieldMeasurement.xsd"/>
+    <!--  -->
+    <complexType name="AbstractMeasurementPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:AbstractMeasurement"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractMeasurement" substitutionGroup="gml:AbstractFeature"/>
+    <!--  -->
+    <complexType name="AbstractMeasurementType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element minOccurs="0" ref="gml:validTime">
+                        <annotation>
+                            <documentation>WFS Temporal Query compatible time element that defines the time instant or time period at which the raw measurement was observed in the field.</documentation>
+                        </annotation>
+                    </element>
+                    <element maxOccurs="unbounded" minOccurs="0" name="aprioriScalar" type="geo:ValueType"/>
+                    <element minOccurs="0" name="fromProject" type="geo:ProjectPropertyType"/>
+                    <element minOccurs="0" name="source" type="geo:AbstractMeasurementSourcePropertyType">
+                        <annotation>
+                            <documentation>A reference to the source of the measurement. An example is a static GNSS baseline reduction from a pair of RINEX files via baseline processing software. Another example is atmospheric correction of a raw EDM measurement. Optional.</documentation>
+                        </annotation>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="Measurement" substitutionGroup="geo:AbstractMeasurement" type="geo:MeasurementType">
+        <annotation>
+            <documentation>A general container for any geodetic measurement. This element will be deprecated in a subsequent version of GeodesyML subject to the requirements coverage provided by the specific named measurement types such as GNSSBaseline, DirectionSet, OrthometricHeight, etc.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="MeasurementType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="type" type="gml:CodeType">
+                        <annotation>
+                            <documentation>Type of measurement. Typical examples (from the DynaNet manual) are:
+                                Measurement types
+                                A Horizontal angles (uncorrelated)
+                                B Geodetic azimuth (or bearing)
+                                C Ellipsoid chord distance
+                                D Direction set
+                                E Ellipsoid arc distance 
+                                G Single GNSS baseline
+                                H Orthometric height
+                                I Astronomic latitude
+                                J Astronomic longitude
+                                K Astronomic (Laplace) azimuth
+                                L Orthometric height difference
+                                M Mean sea level (MSL) arc distance 
+                                P Geodetic latitude
+                                Q Geodetic longitude
+                                R Ellipsoid height
+                                S Slope (direct) distance
+                                V Zenith distance
+                                X GNSS baseline cluster (full correlations)
+                                Y GNSS point cluster (full correlations)
+                                Z Vertical angle
+                            </documentation>
+                        </annotation>
+                    </element>
+                    <element maxOccurs="unbounded" minOccurs="0" name="MeasurementLine" type="geo:MeasurementLineType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="linePairQuality" type="geo:MeasurementLineCovarianceType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="MeasurementPoint" type="geo:MeasurementPointType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="pointPairQuality" type="geo:MeasurementPointCovarianceType"/>
+                </sequence>
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="MeasurementPointType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="atSetup" type="geo:SetupPropertyType"/>
+                    <element name="atNode" type="geo:NodePropertyType"/>
+                    <element minOccurs="0" name="atHeight" type="gml:MeasureType"/>
+                    <element name="value">
+                        <complexType>
+                            <simpleContent>
+                                <extension base="double">
+                                    <attribute name="uomLabel" type="NCName"/>
+                                </extension>
+                            </simpleContent>
+                        </complexType>
+                    </element>
+                    <element maxOccurs="unbounded" minOccurs="0" ref="geo:AbstractQuality"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="MeasurementLineType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element minOccurs="0" name="atSetup" type="geo:SetupPropertyType"/>
+                    <element minOccurs="0" name="toSetup" type="geo:SetupPropertyType"/>
+                    <element name="atNode" type="geo:NodePropertyType"/>
+                    <element minOccurs="0" name="atHeight" type="gml:MeasureType"/>
+                    <element name="toNode" type="geo:NodePropertyType"/>
+                    <element minOccurs="0" name="toHeight" type="gml:MeasureType"/>
+                    <element name="value">
+                        <complexType>
+                            <simpleContent>
+                                <extension base="gml:doubleList">
+                                    <attribute name="uomLabels" type="gml:NCNameList"/>
+                                </extension>
+                            </simpleContent>
+                        </complexType>
+                    </element>
+                    <element maxOccurs="unbounded" minOccurs="0" ref="geo:AbstractQuality"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <complexType name="MeasurementLineCovarianceType">
+        <annotation>
+            <documentation>Covariances between measurementLines.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="atLine" type="gml:ReferenceType"/>
+                    <element name="toLine" type="gml:ReferenceType"/>
+                    <element ref="geo:AbstractQuality"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <complexType name="MeasurementPointCovarianceType">
+        <annotation>
+            <documentation>Covariances between measurementLines.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="atPoint" type="gml:ReferenceType"/>
+                    <element name="toPoint" type="gml:ReferenceType"/>
+                    <element ref="geo:AbstractQuality"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="HorizontalAngle" substitutionGroup="geo:AbstractMeasurement" type="geo:HorizontalAngleType"/>
+    <!--  -->
+    <complexType name="HorizontalAngleType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="base" type="geo:MeasurementPointType">
+                        <annotation>
+                            <documentation>The base is a reference to the node at which the angle was measured (the instrument setup). The base/value element is ignored and by convention should be blank.</documentation>
+                        </annotation>
+                    </element>
+                    <element name="angle" type="geo:MeasurementLineType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GeodeticAzimuth" substitutionGroup="geo:AbstractMeasurement" type="geo:GeodeticAzimuthType"/>
+    <!-- -->
+    <complexType name="GeodeticAzimuthType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="azimuth" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="EllipsoidChordDistance" substitutionGroup="geo:AbstractMeasurement" type="geo:EllipsoidChordDistanceType"/>
+    <!-- -->
+    <complexType name="EllipsoidChordDistanceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="distance" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="EllipsoidArcDistance" substitutionGroup="geo:AbstractMeasurement" type="geo:EllipsoidArcDistanceType"/>
+    <!-- -->
+    <complexType name="EllipsoidArcDistanceType">
+        <annotation>
+            <documentation>Ellipsoid Arc Distances store the same data structure as Ellipsoid Chord Distances and differ only in implementation, thus it is safe to use an alias.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:EllipsoidChordDistanceType"/>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="DirectionSet" substitutionGroup="geo:AbstractMeasurement" type="geo:DirectionSetType"/>
+    <!-- -->
+    <complexType name="DirectionSetType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="direction" type="geo:MeasurementLineType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="directionPairQuality" type="geo:MeasurementLineCovarianceType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GNSSBaseline" substitutionGroup="geo:AbstractMeasurement" type="geo:GNSSBaselineType"/>
+    <!-- -->
+    <complexType name="GNSSBaselineType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="vector" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="OrthometricHeight" substitutionGroup="geo:AbstractMeasurement" type="geo:OrthometricHeightType"/>
+    <!-- -->
+    <complexType name="OrthometricHeightType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="orthometricHeight" type="geo:MeasurementPointType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="HeightDifference" substitutionGroup="geo:AbstractMeasurement" type="geo:HeightDifferenceType"/>
+    <!-- -->
+    <complexType name="HeightDifferenceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="heightDifference" type="geo:MeasurementLineType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="OrthometricHeightDifference" substitutionGroup="geo:AbstractMeasurement" type="geo:OrthometricHeightDifferenceType"/>
+    <!-- -->
+    <complexType name="OrthometricHeightDifferenceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="heightDifference" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="AstronomicLatitude" substitutionGroup="geo:AbstractMeasurement" type="geo:AstronomicLatitudeType"/>
+    <!-- -->
+    <complexType name="AstronomicLatitudeType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="latitude" type="geo:MeasurementPointType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="AstronomicLongitude" substitutionGroup="geo:AbstractMeasurement" type="geo:AstronomicLongitudeType"/>
+    <!-- -->
+    <complexType name="AstronomicLongitudeType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="longitude" type="geo:MeasurementPointType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="AstronomicAzimuth" substitutionGroup="geo:AbstractMeasurement" type="geo:AstronomicAzimuthType"/>
+    <!-- -->
+    <complexType name="AstronomicAzimuthType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="azimuth" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GeodeticLatitude" substitutionGroup="geo:AbstractMeasurement" type="geo:GeodeticLatitudeType"/>
+    <!-- -->
+    <complexType name="GeodeticLatitudeType">
+        <complexContent>
+            <extension base="geo:AstronomicLatitudeType"/>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GeodeticLongitude" substitutionGroup="geo:AbstractMeasurement" type="geo:GeodeticLongitudeType"/>
+    <!-- -->
+    <complexType name="GeodeticLongitudeType">
+        <complexContent>
+            <extension base="geo:AstronomicLongitudeType"/>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="MeanSeaLevelArcDistance" substitutionGroup="geo:AbstractMeasurement" type="geo:MeanSeaLevelArcDistanceType"/>
+    <!-- -->
+    <complexType name="MeanSeaLevelArcDistanceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="arcDistance" type="geo:MeasurementLineType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="SlopeDistance" substitutionGroup="geo:AbstractMeasurement" type="geo:SlopeDistanceType"/>
+    <!-- -->
+    <complexType name="SlopeDistanceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="slopeDistance" type="geo:MeasurementLineType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="EllipsoidHeight" substitutionGroup="geo:AbstractMeasurement" type="geo:EllipsoidHeightType"/>
+    <!-- -->
+    <complexType name="EllipsoidHeightType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="ellipsoidHeight" type="geo:MeasurementPointType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="ZenithDistance" substitutionGroup="geo:AbstractMeasurement" type="geo:ZenithDistanceType"/>
+    <!-- -->
+    <complexType name="ZenithDistanceType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="zenithDistance" type="geo:MeasurementLineType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="VerticalAngle" substitutionGroup="geo:AbstractMeasurement" type="geo:VerticalAngleType"/>
+    <!-- -->
+    <complexType name="VerticalAngleType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="verticalAngle" type="geo:MeasurementLineType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GNSSBaselineCluster" substitutionGroup="geo:AbstractMeasurement" type="geo:GNSSBaselineClusterType"/>
+    <!-- -->
+    <complexType name="GNSSBaselineClusterType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="Baseline" type="geo:MeasurementLineType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="baselinePairQuality" type="geo:MeasurementLineCovarianceType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="GNSSPointCluster" substitutionGroup="geo:AbstractMeasurement" type="geo:GNSSPointClusterType"/>
+    <!-- -->
+    <complexType name="GNSSPointClusterType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="point" type="geo:MeasurementPointType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="pointPairQuality" type="geo:MeasurementPointCovarianceType"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="DInSARWrapped" substitutionGroup="geo:AbstractMeasurement" type="geo:DInSARWrappedType"/>
+    <!-- -->
+    <complexType name="DInSARWrappedType">
+        <complexContent>
+            <extension base="geo:AbstractMeasurementType">
+                <sequence>
+                    <element name="captureSystem" type="gml:CodeType"/>
+                    <!-- the start date and end date are catered for in the gml:validTime element in geo:AbstractMeasurementType -->
+                    <element name="mFrame" type="decimal"/>
+                    <element name="sFrame" type="decimal"/>
+                    <element name="temporalBaseline" type="decimal">
+                        <annotation>
+                            <documentation>Decimal days</documentation>
+                        </annotation>
+                    </element>
+                    <element name="perpendicularBaseline" type="geo:ValueType"/>
+                    <element name="track" type="integer"/>
+                    <element name="heading" type="gml:CodeType"/>
+                    <element name="polarity" type="gml:CodeType"/>
+                    <element name="centre" type="geo:ValueType">
+                        <annotation>
+                            <documentation>Geodetic coordinate lat/lon</documentation>
+                        </annotation>
+                    </element>
+                    <element name="lookAngle" type="geo:ValueType"/>
+                    <element minOccurs="0" name="imageFormat" type="gml:CodeType"/>
+                    <element minOccurs="0" ref="gml:RectifiedGridCoverage"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+</schema>

--- a/schemas/geodesyml/0.6/measurement.xsd
+++ b/schemas/geodesyml/0.6/measurement.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/monumentInfo.xsd
+++ b/schemas/geodesyml/0.6/monumentInfo.xsd
@@ -1,0 +1,306 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <include schemaLocation="geodeticMonument.xsd"/>
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011</p>
+            <ul>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/baseMonumentInfoLib.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/formInformation.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/monumentInfo.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/moreInformation.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/siteIdentification.xsd</li>
+                <li>http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/monumentInfo/2004/siteLocation.xsd</li>
+            </ul>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Combined into single file</li>
+                <li>In SiteLocation, replaced country with 3-letter countryISOCode</li>
+                <li>In MoreInformation, added digital object identifier element (DOI)</li>
+                <li>In SiteIdentification, added monumentNumber and receiverNumber</li>
+                <li>Changed type of single date elements to gml:TimePositionType</li>
+                <li>Replaced enumerations with gml code lists</li>
+                <li>Changed type of numerical quantities from string to decimal</li>
+                <li>Changed latitude and longitude elements from degrees-minutes-seconds to decimal degrees</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <!-- Defined SimpleTypes for use with Site Identification Meta data schema -->
+    <simpleType name="geologicCharacteristicType">
+        <restriction base="string">
+            <enumeration value="BEDROCK"/>
+            <enumeration value="Bedrock"/>
+            <enumeration value="CLAY"/>
+            <enumeration value="Clay"/>
+            <enumeration value="GRAVEL"/>
+            <enumeration value="Gravel"/>
+            <enumeration value="SAND"/>
+            <enumeration value="Sand"/>
+            <enumeration value="SEDIMENTS"/>
+            <enumeration value="Sediments"/>
+            <enumeration value="CONGLOMERATE"/>
+            <enumeration value="Conglomerate"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <simpleType name="monumentDescriptionTypeOfType">
+        <restriction base="string">
+            <enumeration value="pillar"/>
+            <enumeration value="brass plate"/>
+            <enumeration value="steel mast"/>
+            <enumeration value="shallow rod/braced antenna mount"/>
+            <enumeration value="removeable tripod / concrete pad"/>
+            <enumeration value="Wyatt/Agnew drilled-braced"/>
+            <enumeration value="Wyatt/Agnew driven braced"/>
+            <enumeration value="rock-pin/metal-tripod"/>
+            <enumeration value="rock-pin"/>
+            <enumeration value="glued-rod"/>
+            <enumeration value="wall"/>
+        </restriction>
+    </simpleType>
+    <simpleType name="bedrockTypeOfType">
+        <restriction base="string">
+            <enumeration value="IGNEOUS"/>
+            <enumeration value="Igneous"/>
+            <enumeration value="Metaigneous"/>
+            <enumeration value="METAMORPHIC"/>
+            <enumeration value="Metamorphic"/>
+            <enumeration value="GRANITE"/>
+            <enumeration value="Granite"/>
+            <enumeration value="SEDIMENTARY"/>
+            <enumeration value="Sedimentary"/>
+            <enumeration value="CONGLOMERATE"/>
+            <enumeration value="Conglomerate"/>
+            <enumeration value="N/A"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <simpleType name="bedrockConditionsType">
+        <restriction base="string">
+            <enumeration value="FRESH"/>
+            <enumeration value="Fresh"/>
+            <enumeration value="JOINTED"/>
+            <enumeration value="Jointed"/>
+            <enumeration value="FRACTURED"/>
+            <enumeration value="Fractured"/>
+            <enumeration value="WEATHERED"/>
+            <enumeration value="Weathered"/>
+            <enumeration value="N/A"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <simpleType name="fractureSpacingTypeOfType">
+        <restriction base="string">
+            <enumeration value="1-10cm"/>
+            <enumeration value="11-50cm"/>
+            <enumeration value="51-200cm"/>
+            <enumeration value="over 200cm"/>
+            <enumeration value="N/A"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <simpleType name="faultZonesNearbyType">
+        <restriction base="string">
+            <enumeration value="Yes"/>
+            <enumeration value="No"/>
+            <enumeration value="Name_of_Zone"/>
+            <enumeration value=""/>
+        </restriction>
+    </simpleType>
+    <!--
+    <simpleType name="dateInstalledType">
+        <restriction base="string">
+            <pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z"/>
+        </restriction>
+    </simpleType>
+    -->
+    <!-- SimpleType for use with Site Location Meta data schema -->
+    <simpleType name="tectonicPlateTypeOfTypes">
+        <restriction base="string">
+            <enumeration value="African"/>
+            <enumeration value="African Indian/Australia"/>
+            <enumeration value="African Eurasian"/>
+            <enumeration value="Antarctic"/>
+            <enumeration value="Arabian"/>
+            <enumeration value="Caribbean"/>
+            <enumeration value="Cocos"/>
+            <enumeration value="Eurasian"/>
+            <enumeration value="Indian/Australian"/>
+            <enumeration value="Nazca"/>
+            <enumeration value="North America"/>
+            <enumeration value="North America Pacific"/>
+            <enumeration value="Pacific"/>
+            <enumeration value="Phillipine"/>
+            <enumeration value="South American"/>
+            <enumeration value="South American African"/>
+            <enumeration value="Juan De Fuca"/>
+            <enumeration value="Scotia"/>
+        </restriction>
+    </simpleType>
+
+    <complexType name="FormInformationPropertyType">
+        <sequence>
+            <element ref="geo:FormInformation" minOccurs="0"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+
+    <element name="FormInformation" type="geo:FormInformationType"/>
+
+    <complexType name="FormInformationType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="preparedBy" type="string"/>
+                    <element name="datePrepared" type="gml:TimePositionType"/>
+                    <element name="reportType" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="MoreInformationPropertyType">
+        <sequence>
+            <element ref="geo:MoreInformation" minOccurs="0"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+
+    <element name="MoreInformation" type="geo:MoreInformationType"/>
+
+    <complexType name="MoreInformationType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element maxOccurs="unbounded" name="dataCenter" type="string"/>
+                    <element name="urlForMoreInformation" type="string"/>
+                    <element name="siteMap" type="string"/>
+                    <element name="siteDiagram" type="string"/>
+                    <element name="horizonMask" type="string"/>
+                    <element name="monumentDescription" type="string"/>
+                    <element name="sitePictures" type="string"/>
+                    <element minOccurs="0" name="notes" type="string"/>
+                    <element name="antennaGraphicsWithDimensions" type="string"/>
+                    <element name="insertTextGraphicFromAntenna" type="string"/>
+                    <element name="DOI" type="gml:CodeType">
+                        <annotation>
+                            <documentation>Data Digital Object Identifier</documentation>
+                        </annotation>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="SiteIdentificationPropertyType">
+        <sequence>
+            <element ref="geo:SiteIdentification" minOccurs="0"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+
+    <element name="SiteIdentification" type="geo:SiteIdentificationType"/>
+
+    <complexType name="SiteIdentificationType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="siteName" type="string"/>
+                    <element name="fourCharacterID" type="string"/>
+                    <element minOccurs="0" name="monumentNumber">
+                        <annotation>
+                            <documentation>Number of monuments at the site</documentation>
+                        </annotation>
+                        <simpleType>
+                            <restriction base="integer">
+                                <totalDigits value="1"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element minOccurs="0" name="receiverNumber">
+                        <annotation>
+                            <documentation>Number of receivers at the site</documentation>
+                        </annotation>
+                        <simpleType>
+                            <restriction base="integer">
+                                <totalDigits value="1"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element minOccurs="0" name="monumentInscription" type="string"/>
+                    <element name="iersDOMESNumber" type="string"/>
+                    <element name="cdpNumber" type="string"/>
+                    <!-- TODO: use gco -->
+                    <element minOccurs="0" name="monumentDescription" type="gml:CodeType"/>
+                    <element minOccurs="0" name="heightOfTheMonument" type="double"/>
+                    <element minOccurs="0" name="monumentFoundation" type="string"/>
+                    <element minOccurs="0" name="foundationDepth" type="double"/>
+                    <element minOccurs="0" name="markerDescription" type="string"/>
+                    <element minOccurs="0" name="dateInstalled" type="gml:TimePositionType"/>
+                    <!-- TODO: use gco -->
+                    <element minOccurs="0" name="geologicCharacteristic" type="gml:CodeType"/>
+                    <element minOccurs="0" name="bedrockType" type="string"/>
+                    <element minOccurs="0" name="bedrockCondition" type="string"/>
+                    <element minOccurs="0" name="fractureSpacing" type="string"/>
+                    <!-- TODO: use gco -->
+                    <element minOccurs="0" name="faultZonesNearby" type="gml:CodeType"/>
+                    <element minOccurs="0" name="distance-Activity" type="string"/>
+                    <element minOccurs="0" name="notes" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="cartesianPosition">
+        <sequence>
+	       <element ref="gml:Point"/>
+	    </sequence>
+    </complexType>
+    <complexType name="geodeticPosition">
+        <sequence>
+           <element ref="gml:Point"/>
+        </sequence>
+    </complexType>   
+
+    <complexType name="SiteLocationPropertyType">
+        <sequence>
+            <element ref="geo:SiteLocation" minOccurs="0"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+
+    <element name="SiteLocation" type="geo:SiteLocationType"/>
+    
+    <complexType name="SiteLocationType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+                    <element name="city" type="string"/>
+                    <element name="state" type="string"/>
+                    <element name="countryCodeISO" type="geo:countryCodeType" />
+                    <!-- TODO: use gco -->
+                    <element name="tectonicPlate" type="gml:CodeType"/>
+                    
+                    <element name="approximatePositionITRF">
+                        <complexType>
+                            <!-- TODO Allow one or both, but not none of the allowed positioning points -->
+                            <sequence>
+                                <element name="cartesianPosition" type="geo:cartesianPosition" minOccurs="0"/>
+                                <element name="geodeticPosition" type="geo:geodeticPosition" minOccurs="0"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    
+                    <element name="notes" type="string"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>    
+</schema>

--- a/schemas/geodesyml/0.6/monumentInfo.xsd
+++ b/schemas/geodesyml/0.6/monumentInfo.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
     <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
     <include schemaLocation="geodeticMonument.xsd"/>

--- a/schemas/geodesyml/0.6/observationSystem.xsd
+++ b/schemas/geodesyml/0.6/observationSystem.xsd
@@ -1,0 +1,429 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <include schemaLocation="document.xsd"/>
+    <include schemaLocation="quality.xsd"/>
+    <include schemaLocation="lineage.xsd"/>
+    <complexType abstract="true" name="AbstractMonumentType">
+        <annotation>
+            <documentation>Contains information about the physical monument.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="type" type="gml:CodeWithAuthorityType">
+                        <annotation>
+                            <documentation>Monument Type Code e.g. STEEL PILLAR</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" ref="geo:Status">
+                        <annotation>
+                            <documentation>Status of Monument.</documentation>
+                        </annotation>
+                    </element>
+                    <element minOccurs="0" name="installedBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element minOccurs="0" name="installedDate" type="gml:TimePositionType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="SitePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Site"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="MonumentPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Monument"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <complexType name="SupplementaryMarkPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:SupplementaryMark"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Site" substitutionGroup="gml:AbstractFeature" type="geo:SiteType"/>
+    <!--  -->
+    <complexType name="SiteType">
+        <annotation>
+            <documentation>A Site is the umbrella element containing all physical information about a particular observing system site. All setups, nodes and observation quality elements reference a site. Conversely, measurements and positions do not reference a physical site but rather they reference the node abstraction. There can be more than one node that references the one site, but each node must have a unique authority. E.g. Yarragadee CORS can have a Reg13 node (or site certificate) and a national adjustment node. Both reference the same site and thus simultaneously reference the same setup and observation quality, but the estimated coordinates and velocities with associated quality can be different and this is dependent on the business rules of the authority.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractMonumentType">
+                <sequence>
+                    <element minOccurs="0" name="Monument" type="geo:MonumentPropertyType"/>
+                    <element maxOccurs="unbounded" minOccurs="0" name="SupplementaryMark" type="geo:SupplementaryMarkPropertyType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="Monument" substitutionGroup="gml:AbstractFeature" type="geo:MonumentType"/>
+    <!--  -->
+    <complexType name="MonumentType">
+        <annotation>
+            <documentation>Contains physical and geological information about the Monument. The meta-data and geological elements are derived from the SOPAC Site Log schema element mi:siteIdentification.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractMonumentType">
+                <sequence>
+                    <element name="inscription" type="string"/>
+                    <element name="monumentDescription" type="gml:CodeWithAuthorityType"/>
+                    <element name="height" type="geo:SingleValueType"/>
+                    <element name="foundation" type="gml:CodeWithAuthorityType"/>
+                    <element name="foundationDepth" type="geo:SingleValueType"/>
+                    <element name="markerDescription" type="string"/>
+                    <element name="geologicCharacteristic" type="gml:CodeWithAuthorityType"/>
+                    <element name="bedrockType" type="gml:CodeWithAuthorityType"/>
+                    <element name="bedrockCondition" type="gml:CodeWithAuthorityType"/>
+                    <element name="fractureSpacing" type="gml:CodeWithAuthorityType"/>
+                    <element name="faultZonesNearby" type="gml:CodeWithAuthorityType"/>
+                    <element minOccurs="0" name="distanceActivity" type="gml:CodeWithAuthorityType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="SupplementaryMark" substitutionGroup="gml:AbstractFeature" type="geo:SupplementaryMarkType"/>
+    <!--  -->
+    <complexType name="SupplementaryMarkType">
+        <annotation>
+            <documentation>Contains information about supplementary Sites at a node.  For example recovery marks, beacons, etc.  These are typically Sites that do not have a unique identifier within the authority.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:MonumentType">
+                <sequence>
+                    <element maxOccurs="unbounded" minOccurs="0" name="relativeOffset" type="geo:RelativeOffsetType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element abstract="true" name="AbstractSiteLog" substitutionGroup="gml:AbstractFeature" type="geo:AbstractSiteLogType"/>
+    <!--  -->
+    <complexType name="AbstractSiteLogType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element minOccurs="0" name="atSite" type="geo:SitePropertyType"/>
+                </sequence>
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="siteVisit" substitutionGroup="gml:AbstractFeature" type="geo:SiteVisitType"/>
+    <!--  -->
+    <complexType name="SiteVisitType">
+        <annotation>
+            <documentation>Contains information about the Site Visit at the site.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="atSite" type="geo:SitePropertyType"/>
+                    <element name="visitDate" type="gml:TimePositionType"/>
+                    <element minOccurs="0" name="visitBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element name="condition" type="gml:CodeType">
+                        <annotation>
+                            <documentation>Condition of Site found during visit.</documentation>
+                        </annotation>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="SiteCertificate" substitutionGroup="geo:Node" type="geo:SiteCertificateType"/>
+    <!--  -->
+    <complexType name="SiteCertificateType">
+        <annotation>
+            <documentation>A Site Certificate is a specialisation of geo:Node used for specially certified coordinate products. An example of this is the Regulation 13 certificate for GNSS CORS issued by Geoscience Australia.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:NodeType">
+                <sequence>
+                    <element minOccurs="0" name="CORSName" type="string"/>
+                    <element name="FourCharID">
+                        <simpleType>
+                            <restriction base="string">
+                                <length value="4"/>
+                            </restriction>
+                        </simpleType>
+                    </element>
+                    <element minOccurs="0" name="Location" type="string"/>
+                    <element minOccurs="0" name="LocalIDNumber" type="string"/>
+                    <element minOccurs="0" name="MarkDescription" type="string"/>
+                    <element minOccurs="0" name="GNSSReceiver" type="geo:InstrumentPropertyType"/>
+                    <element minOccurs="0" name="GNSSAntenna" type="geo:InstrumentPropertyType"/>
+                    <element minOccurs="0" name="AntennaOffset" type="geo:SingleValueType"/>
+                    <element name="Photo" type="geo:DocumentPropertyType"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <complexType name="RelativeOffsetType">
+        <annotation>
+            <documentation>An offset of a supplementary mark to a Site. The type field would refer to the measurement type (usually bearing or distance) and the value is one or more doubles.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:ValueType">
+                <attribute name="srsName" type="anyURI"/>
+                <attribute name="srsDimension" type="positiveInteger"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <complexType name="NodePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Node"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Node" substitutionGroup="gml:AbstractFeature" type="geo:NodeType"/>
+    <!--  -->
+    <complexType name="NodeType">
+        <annotation>
+            <documentation>A node is an abstract entity used to identify the aggregation of measurement and position associations to a site for the purpose of coordinate estimation. The resultant position estimations that are assigned to a node express the position of the site reference point according to the authorities that instantiated the node and performed the estimation for a valid time.
+            To represent a "current node" whereby the begin position for the valid time is known but the end position is not known, it is conventional to use the following example structure:
+            <gml:validTime>
+                    <gml:TimePeriod gml:id="id">
+                        <gml:beginPosition>2015-03-30Z</gml:beginPosition>
+                        <gml:endPosition indeterminatePosition="unknown"/>
+                    </gml:TimePeriod>
+                </gml:validTime>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element minOccurs="0" ref="geo:Status"/>
+                    <element name="aggregationType" type="gml:CodeWithAuthorityType">
+                        <annotation>
+                            <documentation>The aggregation type specifically identifies the business rules that were used to determine the type of movement permissible at this Node for the valid time period.</documentation>
+                        </annotation>
+                    </element>
+                    <element ref="gml:validTime"/>
+                    <element maxOccurs="unbounded" name="atSite" type="geo:SitePropertyType">
+                        <annotation>
+                            <documentation>A Schematron validation must be written to enforce the convention where a geodetic node can have only one atSite, but a cadastral node may have several.</documentation>
+                        </annotation>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="Status" type="geo:FeatureStatusType"/>
+    <!--  -->
+    <complexType name="FeatureStatusType">
+        <annotation>
+            <documentation>This status type Authoritative can be assigned at most once per Position / CRS / Epoch combination.</documentation>
+        </annotation>
+        <sequence>
+            <element name="currentStatus" type="geo:FeatureStatusInstanceType"/>
+            <element minOccurs="0" name="history">
+                <complexType>
+                    <sequence>
+                        <element maxOccurs="unbounded" ref="geo:StatusInstance"/>
+                    </sequence>
+                </complexType>
+            </element>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <element name="StatusInstance" type="geo:FeatureStatusInstanceType"/>
+    <!--  -->
+    <complexType name="FeatureStatusInstanceType">
+        <sequence>
+            <element ref="gml:validTime"/>
+            <element name="statusCode" type="gml:CodeWithAuthorityType">
+                <annotation>
+                    <documentation>Current status of position as sourced from the codeSpace.</documentation>
+                </annotation>
+            </element>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </complexType>
+    <!--  -->
+    <complexType name="PositionPropertyType">
+        <annotation>
+            <documentation>The choice between referencing a geo:Position or a geo:PositionTimeSeries with a TimeSlice reference.</documentation>
+        </annotation>
+        <choice>
+            <sequence minOccurs="0">
+                <element ref="geo:Position"/>
+            </sequence>
+            <sequence>
+                <element minOccurs="0" ref="geo:PositionTimeSeries"/>
+                <element name="TimeSlice" type="gml:ReferenceType"/>
+            </sequence>
+        </choice>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <group name="PositionLineageWithQualityProperties">
+        <sequence>
+            <element maxOccurs="unbounded" ref="geo:AbstractQuality"/>
+            <element minOccurs="0" name="source" type="geo:AbstractPositionSourcePropertyType">
+                <annotation>
+                    <documentation>Position estimation event that was used to generate the parameters for this position. In the case of a geo:PositionTimeSliceType, this element overrides the source specified in the geo:PositionTimeSeriesType complex type.</documentation>
+                </annotation>
+            </element>
+            <group ref="geo:RemarksGroup"/>
+        </sequence>
+    </group>
+    <!--  -->
+    <element name="PositionPairCovariance" substitutionGroup="gml:AbstractFeature" type="geo:PositionPairCovarianceType"/>
+    <!--  -->
+    <complexType name="PositionPairCovarianceType">
+        <annotation>
+            <documentation>Contains position to position covariance information.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="atPosition" type="geo:PositionPropertyType"/>
+                    <element name="toPosition" type="geo:PositionPropertyType"/>
+                    <element ref="geo:Status"/>
+                    <group ref="geo:PositionLineageWithQualityProperties"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <group name="PositionTimeSliceProperties">
+        <annotation>
+            <documentation>
+                This properties group is shared by geo:PositionType and geo:PositionTimeSliceType.
+                
+                A coordinate reprojection should be only permissible under the following constraints:
+                
+                1) A new status is generated and added to the position element stating that the coordinates are re-projected or transformed.
+                2) Along with the above, the source element must be present and contain (a) an xlink to the original position and (b) a reference to the projection/transformation method.
+                3) If the quality element is present in the original coordinate instance then it must be transformed using the same parameters but using the transformation method appropriate to the quality type (PU, VCV etc)
+                4) If a hasVelocity element is present in the original coordinate instance then velocity and associated quality must be transformed using the same parameters but using the transformation method appropriate to velocity.
+                
+                If the above three conditions cannot be met by the WFS, the position element should not be transformed. Perhaps an error or notice should be issued (or appended to the position) stating that the reprojection was unsuccessful due to limitations of the WFS implementation.
+            </documentation>
+        </annotation>
+        <sequence>
+            <element name="coordinates" type="gml:DirectPositionType"/>
+            <group ref="geo:TimeSliceProperties"/>
+            <element minOccurs="0" name="hasVelocity">
+                <complexType>
+                    <sequence>
+                        <element name="velocity" type="geo:DirectVelocityType"/>
+                        <group ref="geo:PositionLineageWithQualityProperties"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <group ref="geo:PositionLineageWithQualityProperties"/>
+        </sequence>
+    </group>
+    <!--  -->
+    <complexType name="DirectVelocityType">
+        <annotation>
+            <documentation>Direct velocity instances hold the parametric velocity values for a moving object within some coordinate reference system (CRS).</documentation>
+        </annotation>
+        <simpleContent>
+            <extension base="gml:doubleList">
+                <attributeGroup ref="gml:SRSReferenceGroup"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!--  -->
+    <element name="AbstractPosition" substitutionGroup="gml:AbstractFeature">
+        <annotation>
+            <documentation>
+                A Position element contains information about a 1d, 2d, or 3d position for a node.  In general a different position record is used for each datum and source.  For example if a 3d adjustment was the source a single 3d position record (e.g. lat, lon, ellipsoid ht) could be used. If there was an AHD height determined this would be a separate 1d position record.
+            </documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element name="Position" substitutionGroup="geo:AbstractPosition" type="geo:PositionType"/>
+    <!--  -->
+    <complexType name="PositionType">
+        <annotation>
+            <documentation>Contains information about a 1d, 2d, or 3d position for a node.  In general a different position record is used for each datum and source.  For example if a 3d adjustment was the source a single 3d position record (e.g. lat, lon, ellipsoid ht) could be used. If there was an AHD height determined this would be a separate 1d position record.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element name="atNode" type="geo:NodePropertyType"/>
+                    <element ref="geo:Status"/>
+                    <group ref="geo:PositionTimeSliceProperties"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="PositionTimeSeries" substitutionGroup="geo:AbstractPosition" type="geo:PositionTimeSeriesType"/>
+    <!--  -->
+    <complexType name="PositionTimeSeriesType">
+        <annotation>
+            <documentation>Contains information about a 1d, 2d, or 3d position for a node.  In general a different position record is used for each datum and source.  For example if a 3d adjustment was the source a single 3d position record (e.g. lat, lon, ellipsoid ht) could be used. If there was an AHD height determined this would be a separate 1d position record.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:DynamicFeatureType">
+                <sequence>
+                    <element name="atNode" type="geo:NodePropertyType"/>
+                    <element ref="geo:Status"/>
+                    <element minOccurs="0" name="source" type="geo:AbstractPositionSourcePropertyType">
+                        <annotation>
+                            <documentation>Estimation (adjustment) that defined position. As of GeodesyML 0.2 this can include any operation type. Retained (not deprecated) because this element can specify the default source for all elements in the history element</documentation>
+                        </annotation>
+                    </element>
+                    <element name="history">
+                        <complexType>
+                            <sequence>
+                                <element maxOccurs="unbounded" ref="geo:PositionTimeSlice"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+                <attributeGroup ref="geo:RequiredSRSReferenceGroup"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="PositionTimeSlice" type="geo:PositionTimeSliceType"/>
+    <!--  -->
+    <complexType name="PositionTimeSliceType">
+        <annotation>
+            <documentation>A geo:AbstractTimeSliceType wrapper for coordinates that allows it to be used in a geo:Position/geo:History trace.</documentation>
+        </annotation>
+        <complexContent>
+            <extension base="gml:AbstractGeometricPrimitiveType">
+                <sequence>
+                    <element minOccurs="0" ref="geo:Status"/>
+                    <group ref="geo:PositionTimeSliceProperties"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/observationSystem.xsd
+++ b/schemas/geodesyml/0.6/observationSystem.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/project.xsd
+++ b/schemas/geodesyml/0.6/project.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <!--  -->
+    <complexType name="ProjectPropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:Project"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="Project" substitutionGroup="gml:AbstractFeature" type="geo:ProjectType"/>
+    <!--  -->
+    <complexType name="ProjectType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+                    <element minOccurs="0" name="status" type="gml:CodeType"/>
+                    <element minOccurs="0" name="managedBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element minOccurs="0" name="specifiedBy" type="gmd:CI_ResponsibleParty_PropertyType"/>
+                    <element minOccurs="0" name="initiatedDate" type="gml:TimePositionType"/>
+                    <element minOccurs="0" name="completedDate" type="gml:TimePositionType"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/schemas/geodesyml/0.6/project.xsd
+++ b/schemas/geodesyml/0.6/project.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
+<schema elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/quality.xsd
+++ b/schemas/geodesyml/0.6/quality.xsd
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <!--  -->
+    <simpleType name="ConfidenceTypeEnumeration">
+        <restriction base="string">
+            <enumeration value="1 sigma"/>
+            <enumeration value="2 sigma"/>
+            <enumeration value="3 sigma"/>
+            <enumeration value="39.4%"/>
+            <enumeration value="86.5%"/>
+            <enumeration value="95%"/>
+            <enumeration value="98.9%"/>
+            <enumeration value="unknown"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <complexType name="ValueType">
+        <annotation>
+            <documentation>Format of values is as per the dictionary identified by the codeSpace attribute. e.g. "sp1v20_positional-uncertainty"</documentation>
+        </annotation>
+        <simpleContent>
+            <extension base="geo:ValueTypeUnion">
+                <attribute name="codeSpace" type="anyURI" use="required"/>
+                <attribute name="uomLabels" type="gml:NCNameList"/>
+                <attribute name="axisLabels" type="gml:NCNameList"/>
+                <attribute name="confidence" type="geo:ConfidenceTypeEnumeration"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!--  -->
+    <simpleType name="ValueTypeUnion">
+        <union memberTypes="gml:doubleList string"/>
+    </simpleType>
+    <!--  -->
+    <complexType name="SingleValueType">
+        <annotation>
+            <documentation>Format of a single value is as per the dictionary identified by the codeSpace attribute. e.g. "sp1v20_positional-uncertainty"</documentation>
+        </annotation>
+        <simpleContent>
+            <extension base="double">
+                <attribute name="codeSpace" type="anyURI"/>
+                <attribute name="uomLabels" type="gml:NCNameList"/>
+                <attribute name="confidence" type="geo:ConfidenceTypeEnumeration"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!--  -->
+    <simpleType name="DescriptiveQualityType">
+        <restriction base="string">
+            <enumeration value="Unknown">
+                <annotation>
+                    <documentation>Unknown is used when the parameter values are provided without a source and without an estimate of quality.</documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="Approximate">
+                <annotation>
+                    <documentation>Approximate is used to describe parameters that have been manually or systematically guessed for the purpose of providing operands for a parameter estimation.</documentation>
+                </annotation>
+            </enumeration>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <complexType name="VCV3x3Type">
+        <annotation>
+            <documentation>A type for 3x3 VCV described as a list of double values.</documentation>
+        </annotation>
+        <simpleContent>
+            <extension base="geo:ValueTypes6">
+                <attribute name="codeSpace" type="anyURI" use="required"/>
+                <attribute name="srsName" type="anyURI">
+                    <annotation>
+                        <documentation>Often the reference frame and coordinate system of the quality matrix matches that of the coordinates, but sometimes these figures can be provided in a difference coordinate system. For example, coordinates could be in geocentric cartesian coordinates, but the quality could be in topocentric (ENU) cartesian coordinates which thurs requires rotation and translation before propagating variance.</documentation>
+                    </annotation>
+                </attribute>
+                <attribute name="uomLabels" type="gml:NCNameList"/>
+                <attribute name="axisLabels" type="gml:NCNameList"/>
+                <attribute name="confidence" type="geo:ConfidenceTypeEnumeration"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!--  -->
+    <simpleType name="ValueTypes6">
+        <union memberTypes="geo:doubleList6 string"/>
+    </simpleType>
+    <!--  -->
+    <simpleType name="doubleList6">
+        <annotation>
+            <documentation>A gml:doubleList of length 6.</documentation>
+        </annotation>
+        <restriction base="gml:doubleList">
+            <length value="6"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <complexType name="VCV2x2Type">
+        <annotation>
+            <documentation>A type for 2x2 VCV described as a list of double values.</documentation>
+        </annotation>
+        <simpleContent>
+            <extension base="geo:ValueTypes3">
+                <attribute name="codeSpace" type="anyURI" use="required"/>
+                <attribute name="srsName" type="anyURI">
+                    <annotation>
+                        <documentation>Often the reference frame and coordinate system of the quality matrix matches that of the coordinates, but sometimes these figures can be provided in a difference coordinate system. For example, coordinates could be in geocentric cartesian coordinates, but the quality could be in topocentric (ENU) cartesian coordinates which thurs requires rotation and translation before propagating variance.</documentation>
+                    </annotation>
+                </attribute>
+                <attribute name="uomLabels" type="gml:NCNameList"/>
+                <attribute name="axisLabels" type="gml:NCNameList"/>
+                <attribute name="confidence" type="geo:ConfidenceTypeEnumeration"/>
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!--  -->
+    <simpleType name="ValueTypes3">
+        <union memberTypes="geo:doubleList3 string"/>
+    </simpleType>
+    <!--  -->
+    <simpleType name="doubleList3">
+        <annotation>
+            <documentation>A gml:doubleList of length 3.</documentation>
+        </annotation>
+        <restriction base="gml:doubleList">
+            <length value="3"/>
+        </restriction>
+    </simpleType>
+    <!--  -->
+    <element name="Value" type="geo:ValueType">
+        <annotation>
+            <documentation>Generic property value holder</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element abstract="true" name="AbstractQuality">
+        <annotation>
+            <documentation>Abstract group for quality values.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element name="NumericSingleQuality" substitutionGroup="geo:AbstractQuality" type="geo:SingleValueType">
+        <annotation>
+            <documentation>A numeric value for quality. This is often the type used to describe Positional Uncertainty, Relative Uncertainty and Survey Uncertainty.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element name="NumericQualityList" substitutionGroup="geo:AbstractQuality" type="geo:ValueType">
+        <annotation>
+            <documentation>A numeric list value for quality. This is often the type used to describe a VCV matrix or some other arbitrary list of values. To specify a VCV matrix of 2x2 or 3x3 dimension it is better to use VCV2D and VCV3D respectively.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <!-- TODO: use gco -->
+    <element name="DescriptiveQuality" substitutionGroup="geo:AbstractQuality" type="gml:CodeType"/>
+    <!--  -->
+    <element name="VCV3D" substitutionGroup="geo:AbstractQuality" type="geo:VCV3x3Type">
+        <annotation>
+            <documentation>Upper triangle of a symmetric 3x3 VCV matrix defined as a list of six doubles.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <element name="VCV2D" substitutionGroup="geo:AbstractQuality" type="geo:VCV2x2Type">
+        <annotation>
+            <documentation>Upper triangle of a symmetric 2x2 VCV matrix defined as a list of three doubles.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+</schema>
+<!-- edited with XMLSpy v2009 (http://www.altova.com) by DEPT OF SUSTAINABILITY & ENVIRONMENT (DEPT OF SUSTAINABILITY & ENVIRONMENT) -->

--- a/schemas/geodesyml/0.6/quality.xsd
+++ b/schemas/geodesyml/0.6/quality.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sopac="http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2004">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/referenceFrame.xsd
+++ b/schemas/geodesyml/0.6/referenceFrame.xsd
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified" xml:lang="en">
+    <annotation>
+        <documentation></documentation>
+    </annotation>
+    <!--  -->
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <include schemaLocation="lineage.xsd"/>
+    <!--  -->
+    <complexType name="TerrestrialReferenceFramePropertyType">
+        <sequence minOccurs="0">
+            <element ref="geo:TerrestrialReferenceFrame"/>
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    </complexType>
+    <!--  -->
+    <element name="TerrestrialReferenceFrame" type="geo:TerrestrialReferenceFrameType" substitutionGroup="gml:GeodeticDatum">
+        <annotation>
+            <documentation>A terrestrial reference frame is a geodetic reference frame (or geodetic datum in previous GML parlance) in which the coordinates of reference or definition monuments are allowed to move. In essence, a terrestrial reference frame is continuously "realised" with the regular addition of new observations on a weekly or daily time scale. To use a terrestrial reference frame, up-to-date transformation products must be available to propagate coordinates and their uncertanties between epochs and between frames.
+            
+            To derive a static reference frame (a GML datum) from a terrestrial reference frame and a dynamic transformation, the source and target epochs of the dynamic transformation are required to compute coordinates in the realisation epoch of the static reference frame.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="TerrestrialReferenceFrameType">
+        <complexContent>
+            <restriction base="gml:GeodeticDatumType">
+                <sequence>
+                    <sequence>
+                        <element ref="gml:metaDataProperty" minOccurs="0" maxOccurs="unbounded"/>
+                        <element ref="gml:description" minOccurs="0"/>
+                        <element ref="gml:descriptionReference" minOccurs="0"/>
+                        <element ref="gml:identifier"/>
+                        <element ref="gml:name" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:remarks" minOccurs="0"/>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:domainOfValidity" minOccurs="0"/>
+                        <element ref="gml:scope" maxOccurs="unbounded"/>
+                        <element ref="gml:anchorDefinition" minOccurs="0"/>
+                        <element ref="gml:realizationEpoch">
+                            <annotation>
+                                <documentation>The realisation epoch is equivalent to the reference epoch for the reference frame. A dynamic terrestrial reference frame must contain a reference epoch.</documentation>
+                            </annotation>
+                        </element>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:primeMeridian"/>
+                        <element ref="gml:ellipsoid"/>
+                    </sequence>
+                </sequence>
+                <attribute ref="gml:id" use="required"/>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="DynamicTransformation" type="geo:DynamicTransformationType" substitutionGroup="gml:AbstractGeneralTransformation">
+        <annotation>
+            <documentation>A dynamic transformation is a coordinate transformation between reference frames where at least one of which is a dynamic or terrestrial reference frame. To derive a static reference frame (a GML datum) from a terrestrial reference frame and a dynamic transformation, either the source and target epochs OR the source epoch and a relative time quantity parameter of the dynamic transformation are required to compute coordinates in the realisation epoch of the static reference frame.
+
+A transformation between reference frames in the static sense requires no temporal parameters. That is, a static reference frame (SRF) such as GDA94 can be transformed to another SRF like AGD66 with seven spatial parameters and no temporal parameters. In contrast, a dynamic reference frame (DRF) such as ITRF2008 (or the upcoming ITRF2014) requires temporal parameters to be transformed to a SRF and vice versa, and this results in the 14-parameter transformation comprised of 7 spatial and 7 temporal-spatial parameters. A fundamental requirement of the 14-parameter transformation is the provision of a time vector relative to the realisation epoch of the dynamic frame. See Dawson &amp; Woods (2010).</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="DynamicTransformationType">
+        <complexContent>
+            <extension base="gml:AbstractGeneralTransformationType">
+                <sequence>
+                    <element name="sourceEpoch" type="gml:TimePositionType"/>
+                    <element name="targetEpoch" type="gml:TimePositionType" minOccurs="0">
+                        <annotation>
+                            <documentation>The absence of a targetEpoch element implies that this transformation has time-dependent parameters. This is the standard configuration of a 14-parameter transformation whereby the latter 7 parameters are coefficients to a time parameter. A residual velocity map would also implicitly have time-dependent parameters. An example of a dynamic transformation that requires a targetEpoch is a 7-parameter transformation (implying no time-dependent parameters) between two dynamic frames, e.g. ITRF2014 to ITRF2008 at epochs 2014-01-01 and 2008-01-01 respectively.</documentation>
+                        </annotation>
+                    </element>
+                    <element name="usesMethod" type="gml:OperationMethodType"/>
+                    <element ref="gml:parameterValue" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="source" type="geo:AbstractDefinitionSourcePropertyType" minOccurs="0" maxOccurs="unbounded">
+                        <annotation>
+                            <documentation>An unbounded list of references to the source of each parameter.</documentation>
+                        </annotation>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="GridTransformation" type="geo:GridTransformationType" substitutionGroup="geo:DynamicTransformation">
+        <annotation>
+            <documentation>A gridded transformation can be either  (1) an absolute deformation model between two defined epochs, or (2) a time-relative transformation such as a velocity map or residual velocity map transformation. A residual linear velocity map is often defined in conjunction with an optional Euler-pole 3-parameter transformation. The application of velocity map transformations require propagation of the initial coordinates to the sourceEpoch of the transformation to derive the appropriate linear velocity vector and uncertainty for that point to be propagated to the target epoch. The target epoch is not specified in a velocity map definition, instead the derived velocity is a time-dependent parameter which can be used to propagate the point to any desired epoch.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="GridTransformationType">
+        <complexContent>
+            <extension base="geo:DynamicTransformationType">
+                <sequence>
+                    <element ref="gml:RectifiedGridCoverage"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!--  -->
+    <element name="DeformationGridTransformation" type="geo:DeformationGridTransformationType" substitutionGroup="geo:GridTransformation">
+        <annotation>
+            <documentation>A deformation grid transformation is an in-frame transformation i.e. sourceCRS and targetCRS are the same. The targetEpoch element is required. Deformation defines an absolute transformation, that is, one that does not have time-dependent parameters. It is often called a patch-model when used in scenarios where deformation has occurred due to an earthquake.</documentation>
+        </annotation>
+    </element>
+    <!--  -->
+    <complexType name="DeformationGridTransformationType">
+        <complexContent>
+            <restriction base="geo:GridTransformationType">
+                <sequence>
+                    <sequence>
+                        <element ref="gml:metaDataProperty" minOccurs="0" maxOccurs="unbounded"/>
+                        <element ref="gml:description" minOccurs="0"/>
+                        <element ref="gml:descriptionReference" minOccurs="0"/>
+                        <element ref="gml:identifier"/>
+                        <element ref="gml:name" minOccurs="0" maxOccurs="unbounded"/>
+                        <element ref="gml:remarks" minOccurs="0"/>
+                        <element ref="gml:domainOfValidity" minOccurs="0"/>
+                        <element ref="gml:scope" maxOccurs="unbounded"/>
+                        <element ref="gml:operationVersion"/>
+                        <element ref="gml:coordinateOperationAccuracy" minOccurs="0" maxOccurs="unbounded"/>
+                        <element ref="gml:sourceCRS"/>
+                        <element ref="gml:targetCRS"/>
+                    </sequence>
+                    <sequence>
+                        <element name="sourceEpoch" type="gml:TimePositionType"/>
+                        <element name="targetEpoch" type="gml:TimePositionType"/>
+                        <element name="usesMethod" type="gml:OperationMethodType"/>
+                        <element ref="gml:parameterValue" minOccurs="0" maxOccurs="unbounded"/>
+                        <element name="source" type="geo:AbstractDefinitionSourcePropertyType" minOccurs="0" maxOccurs="unbounded">
+                            <annotation>
+                                <documentation>An unbounded list of references to the source of each parameter.</documentation>
+                            </annotation>
+                        </element>
+                    </sequence>
+                    <sequence>
+                        <element ref="gml:RectifiedGridCoverage"/>
+                    </sequence>
+                </sequence>
+            </restriction>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="InterpolatedSingleValue" type="geo:InterpolatedSingleValueType" substitutionGroup="geo:AbstractTimeSlice">
+        <annotation>
+            <documentation>The result of an interpolation operation on a gridded transformation or geoid.</documentation>
+        </annotation>
+    </element>
+    <!-- -->
+    <complexType name="InterpolatedSingleValueType">
+        <complexContent>
+            <extension base="geo:AbstractTimeSliceType">
+                <sequence>
+                    <element ref="geo:Status" minOccurs="0"/>
+                    <element ref="geo:Value"/>
+                    <element name="source" type="geo:InterpolatedValueSourcePropertyType" minOccurs="0"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+    <element name="InterpolatedDynamicValue" type="geo:InterpolatedDynamicValueType" substitutionGroup="gml:AbstractFeature">
+        <annotation>
+            <documentation>The time-series result of interpolation operations on a gridded transformation or geoid over a time period.</documentation>
+        </annotation>
+    </element>
+    <!-- -->
+    <complexType name="InterpolatedDynamicValueType">
+        <complexContent>
+            <extension base="geo:DynamicFeatureType">
+                <sequence>
+                    <element ref="geo:Status" minOccurs="0"/>
+                    <element name="source" type="geo:InterpolatedValueSourcePropertyType" minOccurs="0"/>
+                    <element name="history">
+                        <complexType>
+                            <sequence>
+                                <element ref="geo:InterpolatedSingleValue" maxOccurs="unbounded"/>
+                            </sequence>
+                        </complexType>
+                    </element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <!-- -->
+</schema>

--- a/schemas/geodesyml/0.6/referenceFrame.xsd
+++ b/schemas/geodesyml/0.6/referenceFrame.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified" xml:lang="en">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified" xml:lang="en">
     <annotation>
         <documentation></documentation>
     </annotation>

--- a/schemas/geodesyml/0.6/siteLog.xsd
+++ b/schemas/geodesyml/0.6/siteLog.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
+Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    elementFormDefault="qualified" attributeFormDefault="unqualified"
+    xml:lang="en">
+    <annotation>
+        <documentation>
+            <p>Derived from SOPAC IGS Site Log XML Schema 2011 (http://sopac.ucsd.edu/ns/geodesy/doc/igsSiteLog/2011/igsSiteLog.xsd)</p>
+            <p>Modifications from original</p>
+            <ul>
+                <li>Made part of eGeodesy namespace</li>
+                <li>Changed SiteLogType to extend geo:AbstractSiteLogType, which extends gml:AbstractFeatureType</li>
+                <li>Adopted GML property-by-reference convention</li>
+                <li>Removed contactAgency and responsibleAgence and added siteOwner, siteContact, siteMetadataCustodian, siteDataCenter, and siteDataSource</li>
+            </ul>
+        </documentation>
+    </annotation>
+    <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+    <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd/gmd.xsd"/>
+    <include schemaLocation="monumentInfo.xsd">
+        <annotation>
+            <documentation></documentation>
+        </annotation>
+    </include>
+    <include schemaLocation="equipment.xsd"/>
+    <include schemaLocation="localInterferences.xsd"/>
+    <include schemaLocation="contact.xsd"/>
+    <include schemaLocation="dataStreams.xsd"/>
+    <include schemaLocation="observationSystem.xsd"/>
+    <include schemaLocation="commonTypes.xsd"/>
+    <complexType name="SiteLogType">
+        <annotation>
+            <documentation>
+                This derived complexType combines all relevant site metadata schemas to build a complete igs site log schema.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="geo:AbstractSiteLogType">
+                <sequence>
+                    <element name="formInformation" type="geo:FormInformationPropertyType"/>
+                    <element name="siteIdentification" type="geo:SiteIdentificationPropertyType"/>
+                    <element name="siteLocation" type="geo:SiteLocationPropertyType"/>
+                    <element name="gnssReceiver" type="geo:gnssReceiverPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="gnssAntenna" type="geo:gnssAntennaPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="surveyedLocalTie" type="geo:surveyedLocalTiePropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="frequencyStandard" type="geo:frequencyStandardPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="collocationInformation" type="geo:collocationInformationPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="humiditySensor" type="geo:humiditySensorPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="pressureSensor" type="geo:pressureSensorPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="temperatureSensor" type="geo:temperatureSensorPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="waterVaporSensor" type="geo:waterVaporSensorPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="otherInstrumentation" type="geo:otherInstrumentationPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="radioInterference" type="geo:radioInterferencePropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="multipathSource" type="geo:multipathSourcePropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="signalObstruction" type="geo:signalObstructionPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="localEpisodicEffect" type="geo:localEpisodicEffectPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="siteOwner" type="geo:agencyPropertyType" minOccurs="0" maxOccurs="1"/>
+                    <element name="siteContact" type="geo:agencyPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="siteMetadataCustodian" type="geo:agencyPropertyType" minOccurs="1" maxOccurs="1"/>
+                    <element name="siteDataCenter" type="geo:agencyPropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="siteDataSource" type="geo:agencyPropertyType" minOccurs="0" maxOccurs="1"/>
+                    <element name="moreInformation" type="geo:MoreInformationPropertyType" minOccurs="0"/>
+                    <element name="dataStream" type="geo:dataStreamPropertyType" minOccurs="0"/>
+                    <group ref="geo:RemarksGroup"/>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="siteLog" type="geo:SiteLogType" substitutionGroup="geo:AbstractSiteLog"/>
+</schema>

--- a/schemas/geodesyml/0.6/siteLog.xsd
+++ b/schemas/geodesyml/0.6/siteLog.xsd
@@ -3,7 +3,7 @@
 License: CC By 4.0 (http://creativecommons.org/licenses/by/4.0/legalcode)
 Copyright: Scripps Orbit and Permanent Array Center (SOPAC), Commonwealth Government (Geoscience Australia) 2016
 -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.5" version="0.5" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.5" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:xml-gov-au:icsm:egeodesy:0.6" version="0.6" xmlns:geo="urn:xml-gov-au:icsm:egeodesy:0.6" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmd="http://www.isotc211.org/2005/gmd"
     elementFormDefault="qualified" attributeFormDefault="unqualified"
     xml:lang="en">
     <annotation>


### PR DESCRIPTION
Begin development on version 0.6 of GeodesyML by making a copy of version 0.5 XSD files (and associated examples), changing only the schema version number.

See https://github.com/International-GNSS-Service/GeodesyML/pull/1#issuecomment-2254897661.

If we merge this PR, I would also like to rebase PR https://github.com/International-GNSS-Service/GeodesyML/pull/1, so that the proposed changes stand out as shown in the comment referenced above.